### PR TITLE
Update openstacksdk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 configparser >= 3.5.0
 envbash===1.2.0
-openstacksdk===1.0.1
+openstacksdk===1.0.2
 python-heatclient===3.2.0
 python-keystoneclient===5.1.0
 python-novaclient===18.3.0


### PR DESCRIPTION
openstacksdk requirement version needs to be updted from 1.0.1 to 1.0.2 to avoid this error:

ERROR: Cannot install tempest-nfv-plugin==0.0.1.dev672 because these package versions have conflicting dependencies.

The conflict is caused by:
    tempest-nfv-plugin 0.0.1.dev672 depends on openstacksdk===1.0.1
    The user requested (constraint) openstacksdk===1.0.2