### PR TITLE
Fix NUMA aware test for shared migration

### DIFF
--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -231,7 +231,9 @@ NfvPluginOptions = [
                          'sriov-nova': '/var/lib/openstack/config/nova/'
                          '03-sriov-nova.conf'},
                 help='Configuration files'),
-    cfg.BoolOpt('run_live_migration',
-                default=True,
-                help="Setup is able to run live migration")
+    cfg.StrOpt('live_migration_mode',
+               default='block',
+               choices=['block', 'shared', 'none'],
+               help="Migration mode supported. Options: 'block', 'shared', "
+                    "'none' (in case no live migration supported)")
 ]

--- a/nfv_tempest_plugin/tests/scenario/test_nfv_advanced_usecases.py
+++ b/nfv_tempest_plugin/tests/scenario/test_nfv_advanced_usecases.py
@@ -149,10 +149,13 @@ class TestAdvancedScenarios(base_test.BaseTest):
                              "that state.")
 
         if (not CONF.nfv_plugin_options.target_hypervisor
-                and CONF.nfv_plugin_options.run_live_migration):
-            migrate_kw_args = {'block_migration': True, 'force': True}
+                and CONF.nfv_plugin_options.live_migration_mode != 'none'):
+            is_block = True
+            if CONF.nfv_plugin_options.live_migration_mode != 'block':
+                is_block = False
+            migrate_kw_args = {'block_migration': is_block, 'force': True}
             # on 16.X microversion is 2.72
-            if float(CONF.compute.min_microversion) > 2.67:
+            if float(CONF.compute.min_microversion) > 2.67 and is_block:
                 migrate_kw_args.pop('force')
                 migrate_kw_args['block_migration'] = 'auto'
                 # Pre migration step,


### PR DESCRIPTION
The numa_aware_vswitch failed because assumed that the migration type was always block so when migration type shared (e.g. HCI scenario) was used an error was raised. This fix allows to support shared migration by adding a new option to specify want to migrate using shared.