### PR TITLE
    Fix create_server_with_fip not honoring self.fip when fip param is omitted

### DIFF
--- a/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
+++ b/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
@@ -852,6 +852,8 @@ class BareMetalManager(api_version_utils.BaseMicroversionTest,
 
         :return: List of created servers
         """
+        if fip is None:
+            fip = self.fip
         servers = []
         port = {}
 


### PR DESCRIPTION
    Commit 847cb9f changed the default fip parameter from True to None to
    support IPv6 deployments where floating IPs are not needed. However,
    callers that relied on the old default (fip=True) without passing fip
    explicitly — such as test_pinned_srv_live_migration — started getting
    internal fixed IPs instead of floating IPs, causing connectivity checks
    to fail.
    
    Resolve fip=None to self.fip at the top of create_server_with_fip so
    all callers consistently use the external_config floating_ip setting
    as fallback.
    
    Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
