### PR TITLE
Sriov vf metric tests

### DIFF
--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -67,15 +67,15 @@ test-networks:
     network_type: vlan
     ip_version: 4
     port_type: direct
-    # Nova will set the binding profile of this port to trusted=true and will
-    # set it as Trusted VF
-    trusted_vf: true
-    # set if using HW-Offload port when OVS in is in switchdev mode
-    switchdev: true
-    # set on SRIOV nics support.
-    min_qos: true
-    # (Optional) - Do not attach the network to the instance by default
-    skip_srv_attach: true
+    # network_exporter_sriov_vf_metrics: set skip_srv_attach false (or omit).
+    # Do not set trusted_vf/switchdev unless your Nova PCI whitelist requires them.
+
+# Per-test flavor/image selection (optional). When omitted, compute.flavor_ref is used.
+# network_exporter_sriov_vf_metrics also needs a direct test-network (see above) and
+# [nfv_plugin_options] network_exporter_sriov_physnet matching its physical_network.
+tests-setup:
+  - name: network_exporter_sriov_vf_metrics
+    flavor: nfv_qe_base_flavor
 
 # Flavors used by the test.
 # Will be created by the tests during the execution

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -117,6 +117,53 @@ NfvPluginOptions = [
                help='OVS/kernel netdev for the state-test veth (max 15 characters; '
                     'Linux IFNAMSIZ). Host peer is <name> with a -h suffix when '
                     'that fits, otherwise tpst-ovs-pe.'),
+    cfg.IntOpt('network_exporter_traffic_min_bytes_per_packet',
+               default=64,
+               help='Minimum expected byte delta per counted packet when '
+                    'validating tx/rx_bytes increases.'),
+    cfg.StrOpt('network_exporter_sriov_physnet',
+               default='',
+               help='SR-IOV physnet name from tempest_config.yml test-networks '
+                    '(port_type: direct). When set, only that physnet is created '
+                    'for VM boot and ports_filter uses external,direct:<physnet>. '
+                    'Requires test-networks with mgmt, tag: external, and direct '
+                    'port_type. Must match a physical_network known to Neutron ML2.'),
+    cfg.IntOpt('network_exporter_sriov_traffic_ping_count',
+               default=150,
+               help='ICMP echo requests sent between SR-IOV guests for '
+                    'net_vf_receive/transmit_{packets,bytes}_total checks. '
+                    'Without passwordless sudo on the guest, unprivileged ping '
+                    'is limited to 200ms interval (~120s wall clock for 600 '
+                    'packets).'),
+    cfg.IntOpt('network_exporter_sriov_counter_tolerance_pct',
+               default=20,
+               help='Allowed shortfall (percent) versus '
+                    'network_exporter_sriov_traffic_ping_count when checking '
+                    'SR-IOV VF packet/byte counter growth.'),
+    cfg.IntOpt('network_exporter_sriov_rx_drop_flood_packets',
+               default=50000,
+               help='UDP datagrams sent at high rate to the SR-IOV peer IP '
+                    'without a receiver, to induce net_vf_receive_dropped_total '
+                    'increases on the receiver VF.'),
+    cfg.IntOpt('network_exporter_sriov_tx_drop_flood_packets',
+               default=10000,
+               help='UDP datagrams sent from the SR-IOV guest while the host '
+                    'VF link is disabled, to induce net_vf_transmit_dropped_total '
+                    'increases on the sender VF.'),
+    cfg.IntOpt('network_exporter_sriov_broadcast_flood_packets',
+               default=150,
+               help='UDP datagrams sent to the SR-IOV subnet broadcast address '
+                    'to drive net_vf_broadcast_packets_total on the receiver '
+                    'VF. Uses SO_BROADCAST (not ping -b) because many direct '
+                    'SR-IOV segments do not answer broadcast ICMP.'),
+    cfg.IntOpt('network_exporter_sriov_multicast_flood_packets',
+               default=150,
+               help='UDP datagrams sent to 224.0.0.1 on the SR-IOV dataplane '
+                    '(bound to the sender guest IP) to drive '
+                    'net_vf_multicast_packets_total on the receiver VF. '
+                    'Does not rely on a guest socket listener; L2 multicast '
+                    'flooding on the direct segment is enough for the NIC '
+                    'counter.'),
     cfg.BoolOpt('use_neutron_api_v2',
                 default=False,
                 help="Use neutron-tempest-plugin clients"),

--- a/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
+++ b/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
@@ -498,6 +498,12 @@ class BareMetalManager(api_version_utils.BaseMicroversionTest,
             for net in nets:
                 if not net['router:external'] \
                         and 'HA network tenant' not in net['name']:
+                    if not net.get('subnets'):
+                        LOG.warning(
+                            'Skipping network %s (%s) with no subnets when '
+                            'adding router interfaces',
+                            net.get('name'), net.get('id'))
+                        continue
                     subnets.append(net['subnets'][0])
         else:
             subnets.append(mgmt_net['subnet-id'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -49,8 +49,60 @@ OVS_INTERFACE_LINK_STATE_METRIC = 'ovs_interface_link_state'
 OVS_INTERFACE_MTU_BYTES_METRIC = 'ovs_interface_mtu_bytes'
 OVS_INTERFACE_LINK_SPEED_BPS_METRIC = 'ovs_interface_link_speed_bps'
 OVS_INTERFACE_LINK_RESETS_METRIC = 'ovs_interface_link_resets'
+OVS_INTERFACE_RX_PACKETS_METRIC = 'ovs_interface_rx_packets'
+OVS_INTERFACE_TX_PACKETS_METRIC = 'ovs_interface_tx_packets'
+OVS_INTERFACE_RX_BYTES_METRIC = 'ovs_interface_rx_bytes'
+OVS_INTERFACE_TX_BYTES_METRIC = 'ovs_interface_tx_bytes'
+OVS_INTERFACE_STAT_TO_METRIC = {
+    'rx_packets': OVS_INTERFACE_RX_PACKETS_METRIC,
+    'tx_packets': OVS_INTERFACE_TX_PACKETS_METRIC,
+    'rx_bytes': OVS_INTERFACE_RX_BYTES_METRIC,
+    'tx_bytes': OVS_INTERFACE_TX_BYTES_METRIC,
+}
+NET_VF_INFO_METRIC = 'net_vf_info'
+NET_VF_RECEIVE_PACKETS_METRIC = 'net_vf_receive_packets_total'
+NET_VF_TRANSMIT_PACKETS_METRIC = 'net_vf_transmit_packets_total'
+NET_VF_RECEIVE_BYTES_METRIC = 'net_vf_receive_bytes_total'
+NET_VF_TRANSMIT_BYTES_METRIC = 'net_vf_transmit_bytes_total'
+NET_VF_RECEIVE_DROPPED_METRIC = 'net_vf_receive_dropped_total'
+NET_VF_TRANSMIT_DROPPED_METRIC = 'net_vf_transmit_dropped_total'
+NET_VF_BROADCAST_PACKETS_METRIC = 'net_vf_broadcast_packets_total'
+NET_VF_MULTICAST_PACKETS_METRIC = 'net_vf_multicast_packets_total'
+NET_VF_COUNTER_METRICS = (
+    NET_VF_RECEIVE_PACKETS_METRIC,
+    NET_VF_TRANSMIT_PACKETS_METRIC,
+    NET_VF_RECEIVE_BYTES_METRIC,
+    NET_VF_TRANSMIT_BYTES_METRIC,
+    NET_VF_BROADCAST_PACKETS_METRIC,
+    NET_VF_MULTICAST_PACKETS_METRIC,
+)
+NET_VF_ALL_METRICS = (
+    NET_VF_INFO_METRIC,
+    NET_VF_RECEIVE_PACKETS_METRIC,
+    NET_VF_TRANSMIT_PACKETS_METRIC,
+    NET_VF_RECEIVE_BYTES_METRIC,
+    NET_VF_TRANSMIT_BYTES_METRIC,
+    NET_VF_RECEIVE_DROPPED_METRIC,
+    NET_VF_TRANSMIT_DROPPED_METRIC,
+    NET_VF_BROADCAST_PACKETS_METRIC,
+    NET_VF_MULTICAST_PACKETS_METRIC,
+)
+# Host sysfs under .../sriov/vfN/stats/ (same source as net_vf exporter).
+NET_VF_METRIC_TO_SYSFS_STAT = {
+    NET_VF_RECEIVE_PACKETS_METRIC: 'rx_packets',
+    NET_VF_TRANSMIT_PACKETS_METRIC: 'tx_packets',
+    NET_VF_RECEIVE_BYTES_METRIC: 'rx_bytes',
+    NET_VF_TRANSMIT_BYTES_METRIC: 'tx_bytes',
+    NET_VF_RECEIVE_DROPPED_METRIC: 'rx_dropped',
+    NET_VF_TRANSMIT_DROPPED_METRIC: 'tx_dropped',
+}
 # OVN/K8s service metrics (northd, controller, etc.), not compute :9105
 OVN_K8S_METRICS_PORT = ':1981'
+PROM_METRIC_LINE_RE = re.compile(
+    r'^(?P<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)'
+    r'\{(?P<labels>[^}]*)\}\s+'
+    r'(?P<value>-?\d+(?:\.\d+)?)$')
+PROM_LABEL_RE = re.compile(r'(\w+)="([^"]*)"')
 # openstack-network-exporter: 0=standby, 1=active, 2=paused
 OVN_NORTHD_STATUS_VALUES = (0, 1, 2)
 OVN_NORTHD_STATUS_ACTIVE = 1
@@ -69,6 +121,9 @@ LEGACY_STATE_TEST_INTERFACES = (
     'tempest-ovs-state-test',
     'tempest-ovs-state-test-host',
 )
+PING_FAST_INTERVAL_SEC = 0.001
+PING_SLOW_INTERVAL_SEC = 0.2
+PING_MAX_WALL_SECONDS = 120
 
 
 class NetworkExporterMetricsBase(base_test.BaseTest):
@@ -142,6 +197,47 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             return data.get('data', {}).get('result', []), ''
         return None, '; '.join(errors) or 'Prometheus query failed'
 
+    def _fetch_metric_storage_promql_results(self, metric_name):
+        """Query metric-storage Prometheus for instant vector samples."""
+        query = 'last_over_time(%s[5m])' % metric_name
+        results, error = self._query_prometheus(query)
+        if results:
+            return results, ''
+        return [], error or 'metric-storage query failed'
+
+    def _sample_matches_hypervisor(self, labels, hypervisor_ip):
+        """True when a metric-storage sample belongs to hypervisor_ip."""
+        row_text = ' '.join(
+            labels.get(key, '') for key in ('instance', 'fqdn', 'hostname'))
+        for ident in self._hypervisor_identifiers(hypervisor_ip):
+            ident_short = ident.split('.')[0]
+            if ident in row_text or ident_short in row_text:
+                return True
+        return False
+
+    def _metric_storage_samples(self, metric_name, hypervisor_ip=None,
+                                required_labels=None):
+        """Return metric-storage samples filtered by hypervisor and labels."""
+        results, error = self._fetch_metric_storage_promql_results(metric_name)
+        samples = []
+        for result in results:
+            labels = result.get('metric', {})
+            value = result.get('value', [None, None])[1]
+            if value is None:
+                continue
+            if (hypervisor_ip and
+                    not self._sample_matches_hypervisor(labels, hypervisor_ip)):
+                continue
+            if required_labels and any(
+                    labels.get(key) != val
+                    for key, val in required_labels.items()):
+                continue
+            samples.append({
+                'labels': labels,
+                'value': int(float(value)),
+            })
+        return samples, error
+
     def _metric_show(self, metric_name):
         """Query metric-storage Prometheus for metric values."""
         query = 'last_over_time(%s[5m])' % metric_name
@@ -157,6 +253,105 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         except Exception as exc:
             LOG.warning("Prometheus query error: %s", exc)
             return '', str(exc), 1
+
+    def _scrape_compute_metrics_text(self, hypervisor_ip):
+        """Return openstack-network-exporter Prometheus text from a compute node."""
+        cmd_https = "curl -sk https://127.0.0.1:9105/metrics 2>/dev/null"
+        metrics_output = self._ssh_run_on_hypervisor(hypervisor_ip, cmd_https)
+        if metrics_output.strip():
+            return metrics_output
+        cmd_http = "curl -s http://127.0.0.1:9105/metrics 2>/dev/null"
+        return self._ssh_run_on_hypervisor(hypervisor_ip, cmd_http)
+
+    def _guest_has_passwordless_sudo(self, ssh_client):
+        """Return True when the guest accepts ``sudo -n`` without prompting."""
+        try:
+            ssh_client.exec_command('sudo -n true')
+            return True
+        except Exception:
+            return False
+
+    def _send_ping_packets(self, ssh_client, dest_ip, count, min_packets):
+        """Send ICMP echo requests between guests for traffic counter tests.
+
+        Unprivileged ``ping -i 0.001`` is rejected on RHEL/iputils (200ms floor).
+        When passwordless sudo is unavailable, fall back to ``-i 0.2`` bounded by
+        ``PING_MAX_WALL_SECONDS`` so SSH exec does not time out.
+        """
+        errors = []
+        if self._guest_has_passwordless_sudo(ssh_client):
+            for template in (
+                    'timeout %d sudo -n ping -c %d -i %g -W 2 %s',
+                    'ping -c %d -i %g -W 2 %s'):
+                if 'sudo' in template:
+                    wall = max(30, int(count * PING_FAST_INTERVAL_SEC) + 15)
+                    cmd = template % (
+                        wall, count, PING_FAST_INTERVAL_SEC, dest_ip)
+                else:
+                    cmd = template % (
+                        count, PING_FAST_INTERVAL_SEC, dest_ip)
+                LOG.warning('Sending dataplane ping: %s', cmd)
+                try:
+                    output = ssh_client.exec_command(cmd)
+                except Exception as exc:
+                    errors.append('%s -> %s' % (cmd, exc))
+                    continue
+                if '100% packet loss' in (output or ''):
+                    errors.append('%s -> 100%% packet loss' % cmd)
+                    continue
+                return output
+
+        slow_count = min(
+            count,
+            int(PING_MAX_WALL_SECONDS / PING_SLOW_INTERVAL_SEC))
+        if slow_count < min_packets:
+            self.fail(
+                'Cannot send %d ICMP replies (need >=%d) within %ds without '
+                'passwordless sudo on the guest. Lower the traffic ping count '
+                'to <= %d (at %.1fs interval) or grant passwordless sudo for '
+                'ping.' % (
+                    count, min_packets, PING_MAX_WALL_SECONDS, slow_count,
+                    PING_SLOW_INTERVAL_SEC))
+        wall = int(slow_count * PING_SLOW_INTERVAL_SEC) + 15
+        cmd = 'timeout %d ping -c %d -i %g -W 2 %s' % (
+            wall, slow_count, PING_SLOW_INTERVAL_SEC, dest_ip)
+        LOG.warning('Sending dataplane ping (slow path): %s', cmd)
+        try:
+            output = ssh_client.exec_command(cmd)
+        except Exception as exc:
+            errors.append('%s -> %s' % (cmd, exc))
+        else:
+            if '100% packet loss' not in (output or ''):
+                return output
+            errors.append('%s -> 100%% packet loss' % cmd)
+        if errors:
+            detail = '; '.join(errors)
+        else:
+            detail = 'slow ping path failed'
+        self.fail('Ping to %s failed: %s' % (dest_ip, detail))
+
+    def _assert_metric_on_compute_scrape(self, metric_name):
+        """Verify metric_name is exported on at least one compute :9105 scrape."""
+        hypervisors = self._get_hypervisor_ip_from_undercloud()
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisor IPs available for :9105 scrape')
+        found_on = []
+        for hypervisor_ip in hypervisors:
+            for line in self._scrape_compute_metrics_text(
+                    hypervisor_ip).splitlines():
+                stripped = line.strip()
+                if stripped.startswith(metric_name + '{') or stripped.startswith(
+                        metric_name + ' '):
+                    found_on.append(hypervisor_ip)
+                    break
+        self.assertNotEmpty(
+            found_on,
+            "Metric '%s' not found on :9105 scrape from hypervisors %s" % (
+                metric_name, hypervisors))
+        LOG.warning(
+            "Metric '%s' found on compute :9105 scrape from %s",
+            metric_name, found_on)
 
     def _assert_metric_reported(self, metric_name, output_markers=None):
         """Wait until metric_name is present in metric-storage Prometheus."""
@@ -780,3 +975,22 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             self._delete_test_interface, hypervisor_ip, bridge, interface)
         self._ensure_port_up(hypervisor_ip, interface)
         return hypervisor_ip, interface
+
+    def _parse_prom_samples(self, metrics_output, metric_name,
+                            required_labels=None):
+        """Parse Prometheus exposition text into label/value samples."""
+        samples = []
+        for line in (metrics_output or '').splitlines():
+            match = PROM_METRIC_LINE_RE.match(line.strip())
+            if not match or match.group('metric') != metric_name:
+                continue
+            labels = dict(PROM_LABEL_RE.findall(match.group('labels')))
+            if required_labels and any(
+                    labels.get(key) != value
+                    for key, value in required_labels.items()):
+                continue
+            samples.append({
+                'labels': labels,
+                'value': int(float(match.group('value'))),
+            })
+        return samples

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/net_vf_metrics_mixin.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/net_vf_metrics_mixin.py
@@ -1,0 +1,806 @@
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Reusable net_vf metric validation helpers for SR-IOV VF Tempest tests."""
+
+import shlex
+import time
+import unittest
+
+from nfv_tempest_plugin.tests.common import shell_utilities as shell_utils
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class NetVfMetricsMixin(object):
+    """Validate net_vf_* metrics against compute :9105, metric-storage, and sysfs."""
+
+    def _metrics_text_from_hypervisor(self, hypervisor_ip):
+        return self._scrape_compute_metrics_text(hypervisor_ip)
+
+    def _assert_net_vf_metric_reported(self, metric_name):
+        """Assert net_vf* on compute :9105 and in metric-storage Prometheus."""
+        stdout, stderr, returncode = self._metric_show(metric_name)
+        stdout = stdout or ''
+        hypervisor_ip = None
+        if (returncode == 0 and metric_name in stdout and
+                metrics_base.NETWORK_EXPORTER_INSTANCE_PORT in stdout):
+            LOG.warning(
+                "Metric '%s' reported via openstack metric show", metric_name)
+            hypervisors = self._hypervisor_ips_from_metric_stdout(stdout)
+            if hypervisors:
+                hypervisor_ip = hypervisors[0]
+        else:
+            LOG.warning(
+                "openstack metric show unavailable for '%s' (exit %s: %s); "
+                "falling back to compute :9105 SSH scrape",
+                metric_name, returncode, stderr)
+            self._assert_metric_on_compute_scrape(metric_name)
+        if not hypervisor_ip:
+            hypervisor_ip = self._hypervisor_for_net_vf_metric(metric_name)
+        self.assertIsNotNone(
+            hypervisor_ip,
+            "Could not find a hypervisor exporting %s on compute :9105" %
+            metric_name)
+        self._assert_net_vf_metric_present_in_metric_storage(
+            hypervisor_ip, metric_name)
+        return stdout
+
+    def _prom_samples(self, hypervisor_ip, metric_name, required_labels=None,
+                      metrics_output=None):
+        if metrics_output is None:
+            metrics_output = self._metrics_text_from_hypervisor(hypervisor_ip)
+        return self._parse_prom_samples(
+            metrics_output, metric_name, required_labels)
+
+    def _net_vf_sample_key(self, labels):
+        """Stable VF identity shared by compute scrape and metric-storage."""
+        return (labels.get('device'), labels.get('vf'),
+                labels.get('pci_address'))
+
+    def _hypervisor_for_net_vf_metric(self, metric_name):
+        """Return a hypervisor IP that exports metric_name on compute :9105."""
+        for hypervisor_ip in self._get_hypervisor_ip_from_undercloud():
+            if self._prom_samples(hypervisor_ip, metric_name):
+                return hypervisor_ip
+        return None
+
+    def _vf_identity_labels(self, vf_labels):
+        """Label subset used to match one VF across compute and metric-storage."""
+        if not vf_labels:
+            return None
+        return {key: vf_labels[key]
+                for key in ('device', 'vf', 'pci_address')
+                if key in vf_labels}
+
+    def _assert_net_vf_metric_present_in_metric_storage(
+            self, hypervisor_ip, metric_name):
+        """Verify metric series exist on compute :9105 and in metric-storage."""
+        compute_samples = self._prom_samples(hypervisor_ip, metric_name)
+        self.assertNotEmpty(
+            compute_samples,
+            "No %s samples on compute :9105 for %s" % (
+                metric_name, hypervisor_ip))
+        storage_samples, query_error = self._metric_storage_samples(
+            metric_name, hypervisor_ip=hypervisor_ip)
+        self.assertNotEmpty(
+            storage_samples,
+            "%s missing from metric-storage Prometheus for %s "
+            "(compute had %d series). Query error: %s" % (
+                metric_name, hypervisor_ip, len(compute_samples),
+                query_error))
+        compute_keys = {
+            self._net_vf_sample_key(sample['labels'])
+            for sample in compute_samples}
+        storage_keys = {
+            self._net_vf_sample_key(sample['labels'])
+            for sample in storage_samples}
+        overlap = compute_keys & storage_keys
+        self.assertNotEmpty(
+            overlap,
+            "%s on %s: no VF series in common between compute :9105 and "
+            "metric-storage (compute=%d storage=%d series). "
+            "Sample compute keys: %s; storage keys: %s" % (
+                metric_name, hypervisor_ip, len(compute_keys),
+                len(storage_keys), sorted(compute_keys)[:3],
+                sorted(storage_keys)[:3]))
+        LOG.warning(
+            "%s on %s present in compute :9105 and metric-storage "
+            "(%d common VF series of compute=%d storage=%d)",
+            metric_name, hypervisor_ip, len(overlap),
+            len(compute_keys), len(storage_keys))
+
+    def _assert_net_vf_metrics_match_metric_storage(
+            self, hypervisor_ip, metric_name, vf_labels=None):
+        """Compare net_vf* values on compute :9105 vs metric-storage for VF(s)."""
+        identity_labels = self._vf_identity_labels(vf_labels)
+        self.assertIsNotNone(
+            identity_labels,
+            '_assert_net_vf_metrics_match_metric_storage requires vf_labels '
+            'to identify the VF under test')
+        last_detail = ''
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            compute_output = self._metrics_text_from_hypervisor(hypervisor_ip)
+            compute_samples = self._prom_samples(
+                hypervisor_ip, metric_name, identity_labels,
+                metrics_output=compute_output)
+            storage_samples, query_error = self._metric_storage_samples(
+                metric_name, hypervisor_ip=hypervisor_ip,
+                required_labels=identity_labels)
+            if not compute_samples:
+                last_detail = (
+                    'no compute samples for labels %s' % identity_labels)
+            elif not storage_samples:
+                last_detail = (
+                    'no metric-storage samples for labels %s (%s)' % (
+                        identity_labels, query_error))
+            else:
+                storage_by_key = {
+                    self._net_vf_sample_key(sample['labels']): sample['value']
+                    for sample in storage_samples}
+                mismatches = []
+                for sample in compute_samples:
+                    key = self._net_vf_sample_key(sample['labels'])
+                    compute_value = sample['value']
+                    if key not in storage_by_key:
+                        mismatches.append(
+                            'VF %s on compute :9105 but missing in '
+                            'metric-storage' % (key,))
+                        continue
+                    storage_value = storage_by_key[key]
+                    if compute_value != storage_value:
+                        mismatches.append(
+                            'VF %s on %s: compute :9105=%s, '
+                            'metric-storage=%s' % (
+                                key, hypervisor_ip, compute_value,
+                                storage_value))
+                if not mismatches:
+                    LOG.warning(
+                        "%s on %s matches between compute :9105 and "
+                        "metric-storage for labels %s",
+                        metric_name, hypervisor_ip, identity_labels)
+                    return
+                last_detail = '\n'.join(mismatches)
+            LOG.warning(
+                "Attempt %s/%s waiting for %s metric-storage sync on %s: %s",
+                attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                metric_name, hypervisor_ip, last_detail)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            "%s mismatch between compute and metric-storage on %s "
+            "(labels=%s): %s" % (
+                metric_name, hypervisor_ip, identity_labels, last_detail))
+
+    def _vf_labels_from_mac(self, hypervisor_ip, mac_address):
+        vf_ref = shell_utils.get_vf_from_mac(mac_address, hypervisor_ip)
+        if not vf_ref or "_" not in vf_ref:
+            raise unittest.SkipTest(
+                "Could not map MAC %s to host VF on %s. "
+                "Ensure direct SR-IOV ports are present." % (
+                    mac_address, hypervisor_ip))
+        device, vf = vf_ref.rsplit("_", 1)
+        device = device.strip()
+        vf = vf.strip()
+        pci_cmd = (
+            "basename \"$(readlink -f /sys/class/net/%s/device/virtfn%s)\" "
+            "2>/dev/null" % (device, vf))
+        pci_address = self._ssh_run_on_hypervisor(
+            hypervisor_ip, pci_cmd).strip()
+        if not pci_address:
+            raise unittest.SkipTest(
+                "Could not read VF PCI address for %s vf %s on %s" % (
+                    device, vf, hypervisor_ip))
+        numa_cmd = (
+            "cat /sys/bus/pci/devices/%s/numa_node 2>/dev/null" % pci_address)
+        numa_node = self._ssh_run_on_hypervisor(hypervisor_ip, numa_cmd).strip()
+        return {
+            "device": device,
+            "vf": vf,
+            "pci_address": pci_address,
+            "numa_node": numa_node if numa_node else "-1",
+        }
+
+    def _counter_value(self, hypervisor_ip, metric_name, vf_labels):
+        """Read one net_vf counter from compute :9105 for a single VF."""
+        identity = self._vf_identity_labels(vf_labels)
+        samples = self._prom_samples(
+            hypervisor_ip, metric_name, required_labels=identity)
+        if not samples:
+            return None
+        if len(samples) > 1:
+            self.fail(
+                '%s on %s matched multiple VF series for labels %s: %s' % (
+                    metric_name, hypervisor_ip, identity,
+                    [self._net_vf_sample_key(s['labels']) for s in samples]))
+        return samples[0]['value']
+
+    def _storage_counter_value(self, hypervisor_ip, metric_name, vf_labels):
+        """Read one net_vf counter from metric-storage for a single VF."""
+        identity = self._vf_identity_labels(vf_labels)
+        samples, query_error = self._metric_storage_samples(
+            metric_name, hypervisor_ip=hypervisor_ip,
+            required_labels=identity)
+        if not samples:
+            LOG.warning(
+                'No metric-storage sample for %s on %s labels %s: %s',
+                metric_name, hypervisor_ip, identity, query_error)
+            return None
+        if len(samples) > 1:
+            self.fail(
+                '%s in metric-storage on %s matched multiple VF series for '
+                'labels %s' % (metric_name, hypervisor_ip, identity))
+        return samples[0]['value']
+
+    def _vf_promql_filter(self, hypervisor_ip, vf_labels, metric_name):
+        """Return a PromQL snippet for the VF under test (for failure logs)."""
+        identity = self._vf_identity_labels(vf_labels)
+        parts = ['instance="%s%s"' % (
+            hypervisor_ip, metrics_base.NETWORK_EXPORTER_INSTANCE_PORT)]
+        for key in ('device', 'vf', 'pci_address'):
+            if key in identity:
+                parts.append('%s="%s"' % (key, identity[key]))
+        return '%s{%s}' % (metric_name, ','.join(parts))
+
+    def _ssh_run_unchecked_on_hypervisor(self, hypervisor_ip, command):
+        """Run on hypervisor without failing the test (cleanup helpers)."""
+        try:
+            return self._ssh_run_on_hypervisor(hypervisor_ip, command)
+        except Exception as exc:
+            LOG.warning(
+                'Unchecked hypervisor command on %s failed: %s (%s)',
+                hypervisor_ip, command, exc)
+            return ''
+
+    def _lookup_guest_dataplane_iface_by_mac(self, ssh_client, mac_address):
+        """Return guest netdev for a MAC, or None if not found."""
+        mac = mac_address.lower()
+        cmd = (
+            "ip -o link | grep -i '%s' | awk -F': ' '{print $2; exit}'" % mac)
+        raw = ssh_client.exec_command(cmd).strip()
+        iface = raw.split('@')[0].strip() if raw else ''
+        return iface or None
+
+    def _lookup_guest_dataplane_iface_by_ip(self, ssh_client, ip_address):
+        """Return guest netdev carrying a fixed IP, or None if not found."""
+        if ':' in ip_address:
+            match = "inet6 %s/" % ip_address
+        else:
+            match = "inet %s/" % ip_address
+        cmd = (
+            "ip -o addr show | grep '%s' | awk '{print $2; exit}'" % match)
+        raw = ssh_client.exec_command(cmd).strip()
+        return raw.split('@')[0].strip() if raw else None
+
+    def _guest_dataplane_iface(self, ssh_client, mac_address):
+        """Return the guest netdev name for an SR-IOV port MAC address."""
+        iface = self._lookup_guest_dataplane_iface_by_mac(
+            ssh_client, mac_address)
+        if not iface:
+            raise unittest.SkipTest(
+                'Could not resolve guest dataplane interface for MAC %s' % (
+                    mac_address))
+        return iface
+
+    def _guest_dataplane_iface_for_port(self, ssh_client, port):
+        """Locate SR-IOV dataplane netdev by port MAC, else by fixed IP."""
+        iface = self._lookup_guest_dataplane_iface_by_mac(
+            ssh_client, port['mac_address'])
+        if iface:
+            return iface
+        fixed_ips = port.get('fixed_ips') or []
+        if fixed_ips:
+            iface = self._lookup_guest_dataplane_iface_by_ip(
+                ssh_client, fixed_ips[0]['ip_address'])
+            if iface:
+                return iface
+        raise unittest.SkipTest(
+            'Could not resolve guest dataplane interface for port MAC %s '
+            'and fixed IPs %s' % (
+                port['mac_address'],
+                [ip['ip_address'] for ip in fixed_ips]))
+
+    @staticmethod
+    def _is_zero_mac(mac_address):
+        """Return True when a MAC is unset (all zeros)."""
+        mac = (mac_address or '').lower().replace('-', ':')
+        return mac in ('00:00:00:00:00:00',)
+
+    def _read_guest_iface_mac(self, ssh_client, iface):
+        """Return the MAC address from guest sysfs for one netdev."""
+        guest_mac = ssh_client.exec_command(
+            'cat /sys/class/net/%s/address' % iface).strip().lower()
+        if not guest_mac:
+            raise unittest.SkipTest(
+                'Could not read MAC from guest interface %s' % iface)
+        return guest_mac
+
+    def _guest_dataplane_mac(self, ssh_client, mac_address):
+        """Return the MAC address read from the guest SR-IOV netdev."""
+        iface = self._guest_dataplane_iface(ssh_client, mac_address)
+        guest_mac = self._read_guest_iface_mac(ssh_client, iface)
+        return guest_mac, iface
+
+    def _assert_guest_port_mac(self, ssh_client, port, server):
+        """Verify the VM dataplane interface MAC matches the Neutron port."""
+        expected_mac = port['mac_address'].lower()
+        guest_mac, iface = self._guest_dataplane_mac(
+            ssh_client, expected_mac)
+        self.assertEqual(
+            guest_mac, expected_mac,
+            'Guest SR-IOV MAC mismatch on server %s interface %s: '
+            'Neutron port=%s guest=%s' % (
+                server['id'], iface, expected_mac, guest_mac))
+        LOG.warning(
+            'Guest SR-IOV MAC verified on server %s: interface=%s mac=%s',
+            server['id'], iface, guest_mac)
+
+    def _assert_guest_port_mac_not_zero(self, ssh_client, port, server):
+        """Fail when the guest SR-IOV dataplane NIC MAC is all zeros."""
+        iface = self._guest_dataplane_iface_for_port(ssh_client, port)
+        guest_mac = self._read_guest_iface_mac(ssh_client, iface)
+        self.assertFalse(
+            self._is_zero_mac(guest_mac),
+            'Guest SR-IOV interface %s on server %s has all-zero MAC %s '
+            '(Neutron port MAC %s). The VF MAC was not programmed in the '
+            'guest.' % (
+                iface, server['id'], guest_mac, port['mac_address']))
+        LOG.warning(
+            'Guest SR-IOV MAC is non-zero on server %s: interface=%s mac=%s',
+            server['id'], iface, guest_mac)
+
+    @staticmethod
+    def _parse_vf_sysfs_stats_blob(blob):
+        """Parse mlx5-style VF stats file (``tx_dropped : 123`` per line)."""
+        stats = {}
+        for line in (blob or '').splitlines():
+            line = line.strip()
+            if not line or ':' not in line:
+                continue
+            key, _, value = line.partition(':')
+            key = key.strip()
+            value = value.strip()
+            try:
+                stats[key] = int(value)
+            except ValueError:
+                continue
+        return stats
+
+    def _pf_netdevices_for_vf(self, hypervisor_ip, vf_labels):
+        """Return PF netdev name(s) that host VF stats under .../sriov/<vf>/stats."""
+        devices = []
+        seen = set()
+
+        def add(name):
+            name = (name or '').strip()
+            if name and name not in seen:
+                seen.add(name)
+                devices.append(name)
+
+        add(vf_labels['device'])
+        pci = vf_labels.get('pci_address')
+        if not pci:
+            return devices
+        pf_net_cmd = (
+            'bash -c %s' % shlex.quote(
+                'pf=$(readlink -f /sys/bus/pci/devices/%s/physfn 2>/dev/null); '
+                'if [ -n "$pf" ]; then ls "$pf/net" 2>/dev/null; fi' % pci))
+        for line in self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, pf_net_cmd).splitlines():
+            add(line)
+
+        pci_net_cmd = (
+            'bash -c %s' % shlex.quote(
+                'ls /sys/bus/pci/devices/%s/net 2>/dev/null' % pci))
+        for line in self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, pci_net_cmd).splitlines():
+            add(line)
+        return devices
+
+    def _pf_netdev_for_vf_admin(self, hypervisor_ip, vf_labels):
+        """Return PF netdev for ``ip link set dev <pf> vf <n> ...`` on the host."""
+        pci = vf_labels.get('pci_address')
+        if pci:
+            pf_net_cmd = (
+                'bash -c %s' % shlex.quote(
+                    'pf=$(readlink -f /sys/bus/pci/devices/%s/physfn '
+                    '2>/dev/null); '
+                    'if [ -n "$pf" ]; then ls "$pf/net" 2>/dev/null | head -1; '
+                    'fi' % pci))
+            pf_netdev = self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, pf_net_cmd).strip()
+            if pf_netdev:
+                return pf_netdev
+        return vf_labels['device']
+
+    def _vf_sysfs_stats_bases(self, hypervisor_ip, vf_labels):
+        """Candidate sysfs paths for one VF stats file or directory."""
+        vf = vf_labels['vf']
+        bases = []
+        seen = set()
+
+        def add(path):
+            if path not in seen:
+                seen.add(path)
+                bases.append(path)
+
+        for pf_dev in self._pf_netdevices_for_vf(hypervisor_ip, vf_labels):
+            add('/sys/class/net/%s/device/sriov/%s/stats' % (pf_dev, vf))
+            add('/sys/class/net/%s/device/sriov/vf%s/stats' % (pf_dev, vf))
+
+        ib_cmd = (
+            'bash -c %s' % shlex.quote(
+                'for ib in /sys/class/infiniband/*/device; do '
+                'test -e "$ib/sriov/%s/stats" && echo "$ib/sriov/%s/stats"; '
+                'done' % (vf, vf)))
+        for line in self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, ib_cmd).splitlines():
+            add(line.strip())
+        return bases
+
+    def _vf_sysfs_stat_file_paths(self, hypervisor_ip, vf_labels, stat_name):
+        """Per-stat sysfs files (Intel-style .../sriov/N/stats/rx_dropped)."""
+        vf = vf_labels['vf']
+        paths = []
+        seen = set()
+        for pf_dev in self._pf_netdevices_for_vf(hypervisor_ip, vf_labels):
+            for path in (
+                    '/sys/class/net/%s/device/sriov/%s/stats/%s' % (
+                        pf_dev, vf, stat_name),
+                    '/sys/class/net/%s/device/sriov/vf%s/stats/%s' % (
+                        pf_dev, vf, stat_name)):
+                if path not in seen:
+                    seen.add(path)
+                    paths.append(path)
+        return paths
+
+    def _read_vf_stats_at_base(self, hypervisor_ip, stats_base):
+        """Read VF stats from one sysfs file (mlx5 blob) or stats/ directory."""
+        script = (
+            'base=%s; '
+            'if [ -f "$base" ]; then cat "$base"; '
+            'elif [ -d "$base" ]; then '
+            '  for f in "$base"/*; do '
+            '    [ -f "$f" ] || continue; '
+            '    n=$(basename "$f"); v=$(cat "$f" 2>/dev/null); '
+            '    printf "%%s: %%s\\n" "$n" "$v"; '
+            '  done; '
+            'fi' % shlex.quote(stats_base))
+        blob = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip, 'bash -c %s' % shlex.quote(script)).strip()
+        if not blob or 'No such file' in blob:
+            return {}
+        return self._parse_vf_sysfs_stats_blob(blob)
+
+    def _host_vf_sysfs_stats_map(self, hypervisor_ip, vf_labels):
+        """Return all VF stats from host sysfs for the PF/VF under test."""
+        stats_bases = self._vf_sysfs_stats_bases(hypervisor_ip, vf_labels)
+        for stats_base in stats_bases:
+            stats = self._read_vf_stats_at_base(hypervisor_ip, stats_base)
+            if stats:
+                LOG.warning(
+                    'Read VF sysfs stats from %s on %s for labels %s: %s',
+                    stats_base, hypervisor_ip, vf_labels,
+                    sorted(stats.keys()))
+                return stats
+        LOG.warning(
+            'No VF sysfs stats found on %s for labels %s (tried: %s)',
+            hypervisor_ip, vf_labels, stats_bases)
+        return {}
+
+    def _host_vf_sysfs_stat(self, hypervisor_ip, vf_labels, stat_name):
+        """Read one VF counter from host sysfs (same source as net_vf exporter)."""
+        for path in self._vf_sysfs_stat_file_paths(
+                hypervisor_ip, vf_labels, stat_name):
+            raw = self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip,
+                'cat %s 2>/dev/null' % shlex.quote(path)).strip()
+            if raw.isdigit():
+                return int(raw)
+        return self._host_vf_sysfs_stats_map(hypervisor_ip, vf_labels).get(
+            stat_name)
+
+    def _host_vf_sysfs_stats_available(self, hypervisor_ip, vf_labels):
+        """Return sorted VF stat names exposed under host sysfs, or []."""
+        return sorted(self._host_vf_sysfs_stats_map(hypervisor_ip, vf_labels))
+
+    def _vf_prom_storage_values(self, hypervisor_ip, vf_labels, metric_name):
+        """Read one net_vf counter from compute :9105 and metric-storage."""
+        return (
+            self._counter_value(hypervisor_ip, metric_name, vf_labels),
+            self._storage_counter_value(hypervisor_ip, metric_name, vf_labels))
+
+    def _wait_for_vf_prom_storage_aligned(
+            self, hypervisor_ip, vf_labels, metric_name):
+        """Wait until :9105 and metric-storage match before taking a baseline."""
+        identity = self._vf_identity_labels(vf_labels)
+        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            prom, storage = self._vf_prom_storage_values(
+                hypervisor_ip, vf_labels, metric_name)
+            last = {'prom': prom, 'storage': storage}
+            if prom is not None and storage is not None and prom == storage:
+                LOG.warning(
+                    ':9105 and metric-storage aligned for %s on %s: %s. %s',
+                    metric_name, identity, prom, promql)
+                return prom, storage
+            LOG.warning(
+                'Attempt %s/%s waiting for :9105==metric-storage baseline '
+                'on %s for %s: %s',
+                attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                identity, metric_name, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            '%s on %s did not align across compute :9105 and metric-storage '
+            'before baseline for labels %s. Last %s. Per-VF PromQL: %s' % (
+                metric_name, hypervisor_ip, identity, last, promql))
+
+    def _wait_for_vf_prom_and_storage_increase(
+            self, hypervisor_ip, vf_labels, metric_name, baseline_prom,
+            counter_kind, min_delta=None, baseline_storage=None):
+        """Wait for net_vf counter growth on :9105 and metric-storage."""
+        if min_delta is None:
+            min_delta = (self._min_expected_packets()
+                         if counter_kind == 'packets'
+                         else self._min_expected_bytes())
+        if baseline_storage is None:
+            baseline_storage = self._storage_counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+        identity = self._vf_identity_labels(vf_labels)
+        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            prom = self._counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+            storage = self._storage_counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+            prom_delta = (
+                None if prom is None or baseline_prom is None
+                else prom - baseline_prom)
+            storage_delta = (
+                None if storage is None or baseline_storage is None
+                else storage - baseline_storage)
+            last = {
+                'baseline_prom': baseline_prom,
+                'baseline_storage': baseline_storage,
+                'prom': prom,
+                'storage': storage,
+                'prom_delta': prom_delta,
+                'storage_delta': storage_delta,
+                'min_delta': min_delta,
+            }
+            if (prom is not None and storage is not None and
+                    prom_delta is not None and storage_delta is not None and
+                    prom_delta >= min_delta and
+                    storage_delta >= min_delta and
+                    prom == storage):
+                LOG.warning(
+                    '%s on %s increased on compute and metric-storage for %s: '
+                    'value=%s (baseline prom=%s storage=%s, delta=%s). '
+                    'Dashboard filter: %s',
+                    metric_name, hypervisor_ip, identity, prom,
+                    baseline_prom, baseline_storage, prom_delta, promql)
+                return prom_delta
+            LOG.warning(
+                'Attempt %s/%s waiting for %s on %s (need prom/storage '
+                'delta>=%s and prom==storage): %s',
+                attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                metric_name, identity, min_delta, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            '%s on %s did not increase on both compute :9105 and '
+            'metric-storage for labels %s. Required delta>=%s and '
+            'prom==storage. Last %s. Per-VF PromQL: %s' % (
+                metric_name, hypervisor_ip, identity, min_delta, last, promql))
+
+    def _wait_for_vf_counter_aligned_with_sysfs(
+            self, hypervisor_ip, vf_labels, metric_name, sysfs_stat_name,
+            baseline_prom, baseline_sysfs, min_prom_delta, min_sysfs_delta):
+        """Wait until :9105, metric-storage, and sysfs all match for one VF."""
+        identity = self._vf_identity_labels(vf_labels)
+        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            sysfs_now = self._host_vf_sysfs_stat(
+                hypervisor_ip, vf_labels, sysfs_stat_name)
+            prom = self._counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+            storage = self._storage_counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+            sysfs_delta = (
+                None if sysfs_now is None or baseline_sysfs is None
+                else sysfs_now - baseline_sysfs)
+            prom_delta = (
+                None if prom is None or baseline_prom is None
+                else prom - baseline_prom)
+            last = {
+                'baseline_prom': baseline_prom,
+                'baseline_sysfs': baseline_sysfs,
+                'sysfs_now': sysfs_now,
+                'sysfs_delta': sysfs_delta,
+                'prom': prom,
+                'prom_delta': prom_delta,
+                'storage': storage,
+                'min_prom_delta': min_prom_delta,
+                'min_sysfs_delta': min_sysfs_delta,
+            }
+            if None in (sysfs_now, prom, storage, sysfs_delta, prom_delta):
+                LOG.warning(
+                    'Attempt %s/%s waiting for %s alignment on %s: %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    metric_name, identity, last)
+            elif (sysfs_delta >= min_sysfs_delta and
+                  prom_delta >= min_prom_delta and
+                  prom == storage == sysfs_now):
+                LOG.warning(
+                    '%s aligned on %s for %s: sysfs/prom/storage=%s '
+                    '(baseline prom=%s sysfs=%s, deltas prom=%s sysfs=%s). '
+                    'Dashboard filter: %s',
+                    metric_name, hypervisor_ip, identity, prom,
+                    baseline_prom, baseline_sysfs, prom_delta, sysfs_delta,
+                    promql)
+                return prom, sysfs_now
+            else:
+                LOG.warning(
+                    'Attempt %s/%s %s not aligned on %s (need sysfs_delta>=%s '
+                    'prom_delta>=%s and prom==storage==sysfs): %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    metric_name, identity, min_sysfs_delta, min_prom_delta,
+                    last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            '%s on %s did not align across sysfs, compute :9105, and '
+            'metric-storage for labels %s. Required sysfs_delta>=%s '
+            'prom_delta>=%s and prom==storage==sysfs. Last %s. '
+            'Per-VF PromQL (not sum across all VFs): %s' % (
+                metric_name, hypervisor_ip, identity, min_sysfs_delta,
+                min_prom_delta, last, promql))
+
+    def _test_vf_drop_counter_increases(
+            self, metric_name, endpoint_role, traffic_generator,
+            sysfs_stat_name):
+        """Validate net_vf_*_dropped_total increases after induced drops."""
+        self._assert_net_vf_metric_reported(metric_name)
+        ctx = self._build_traffic_context()
+        endpoint = ctx[endpoint_role]
+        hypervisor_ip = endpoint['hypervisor_ip']
+        vf_labels = endpoint['vf_labels']
+        baseline_sysfs = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, sysfs_stat_name)
+        baseline_prom, baseline_storage = (
+            self._wait_for_vf_prom_storage_aligned(
+                hypervisor_ip, vf_labels, metric_name))
+        self.assertIsNotNone(
+            baseline_prom,
+            '%s missing baseline on %s for labels %s' % (
+                metric_name, hypervisor_ip, vf_labels))
+
+        packet_count = self._ping_count()
+        min_packets = self._min_expected_packets()
+        traffic_generator(ctx, packet_count, min_packets)
+
+        sysfs_before = ctx.get('sysfs_drop_before')
+        sysfs_after = ctx.get('sysfs_drop_after')
+        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+
+        if (sysfs_before is not None and sysfs_after is not None and
+                sysfs_after > sysfs_before):
+            sysfs_delta = sysfs_after - sysfs_before
+            baseline_sysfs_val = (
+                baseline_sysfs if baseline_sysfs is not None else sysfs_before)
+            final_prom, final_sysfs = (
+                self._wait_for_vf_counter_aligned_with_sysfs(
+                    hypervisor_ip, vf_labels, metric_name, sysfs_stat_name,
+                    baseline_prom, baseline_sysfs_val, sysfs_delta,
+                    sysfs_delta))
+            LOG.warning(
+                '%s validated with sysfs on %s for %s: prom/sysfs=%s '
+                '(baseline prom=%s sysfs=%s, induced %s->%s). %s',
+                metric_name, endpoint_role, hypervisor_ip, final_prom,
+                baseline_prom, baseline_sysfs_val, sysfs_before, final_sysfs,
+                promql)
+            return
+
+        if (sysfs_before is not None and sysfs_after is not None and
+                sysfs_after <= sysfs_before):
+            raise unittest.SkipTest(
+                'Host VF sysfs %s on %s unchanged after drop induce '
+                '(before=%s after=%s). The NIC/driver may not increment VF '
+                'drop stats for this test method.' % (
+                    sysfs_stat_name, hypervisor_ip, sysfs_before,
+                    sysfs_after))
+
+        LOG.warning(
+            'Host VF sysfs %s unavailable around drop induce on %s for '
+            'labels %s (baseline=%s before=%r after=%r, available=%s); '
+            'validating %s via Prometheus delta and metric-storage. %s',
+            sysfs_stat_name, hypervisor_ip, vf_labels, baseline_sysfs,
+            sysfs_before, sysfs_after,
+            self._host_vf_sysfs_stats_available(hypervisor_ip, vf_labels) or
+            'none', metric_name, promql)
+        self._wait_for_vf_prom_and_storage_increase(
+            hypervisor_ip, vf_labels, metric_name, baseline_prom,
+            'drops', min_delta=1, baseline_storage=baseline_storage)
+
+    def _test_vf_counter_increases_with_traffic(
+            self, metric_name, endpoint_role, counter_kind,
+            traffic_generator=None, traffic_packet_count=None):
+        """Validate one net_vf counter increases under VM dataplane traffic."""
+        self._assert_net_vf_metric_reported(metric_name)
+        ctx = self._build_traffic_context()
+        endpoint = ctx[endpoint_role]
+        hypervisor_ip = endpoint['hypervisor_ip']
+        vf_labels = endpoint['vf_labels']
+        sysfs_stat_name = metrics_base.NET_VF_METRIC_TO_SYSFS_STAT.get(
+            metric_name)
+        baseline_sysfs = None
+        use_sysfs = False
+        if sysfs_stat_name:
+            baseline_sysfs = self._host_vf_sysfs_stat(
+                hypervisor_ip, vf_labels, sysfs_stat_name)
+            if baseline_sysfs is not None:
+                use_sysfs = True
+            else:
+                available = self._host_vf_sysfs_stats_available(
+                    hypervisor_ip, vf_labels)
+                LOG.warning(
+                    'Host VF sysfs %s unavailable on %s for labels %s '
+                    '(available: %s); validating %s via Prometheus delta '
+                    'and metric-storage only. Per-VF query: %s',
+                    sysfs_stat_name, hypervisor_ip, vf_labels,
+                    available or 'none', metric_name,
+                    self._vf_promql_filter(hypervisor_ip, vf_labels,
+                                           metric_name))
+        baseline_prom, baseline_storage = (
+            self._wait_for_vf_prom_storage_aligned(
+                hypervisor_ip, vf_labels, metric_name))
+        self.assertIsNotNone(
+            baseline_prom,
+            '%s missing baseline on %s for labels %s' % (
+                metric_name, hypervisor_ip, vf_labels))
+
+        packet_count = traffic_packet_count or self._ping_count()
+        min_packets = self._min_expected_packets_for_count(packet_count)
+        if counter_kind == 'packets':
+            min_delta = min_packets
+        else:
+            min_delta = self._min_expected_bytes_for_count(packet_count)
+        if traffic_generator is None:
+            self._send_ping_packets(
+                ctx['ssh_sender'], ctx['peer_ip'], packet_count, min_packets)
+        else:
+            traffic_generator(ctx, packet_count, min_packets)
+
+        if use_sysfs:
+            self._wait_for_vf_counter_aligned_with_sysfs(
+                hypervisor_ip, vf_labels, metric_name, sysfs_stat_name,
+                baseline_prom, baseline_sysfs, min_delta, min_delta)
+            LOG.warning(
+                '%s increased with sysfs alignment after SR-IOV traffic '
+                '(%s %s)', metric_name, endpoint_role, counter_kind)
+        else:
+            self._wait_for_vf_prom_and_storage_increase(
+                hypervisor_ip, vf_labels, metric_name, baseline_prom,
+                counter_kind, min_delta=min_delta,
+                baseline_storage=baseline_storage)
+            LOG.warning(
+                '%s increased on Prometheus paths after SR-IOV traffic '
+                '(%s %s)', metric_name, endpoint_role, counter_kind)

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_sriov_vf_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_sriov_vf_metrics.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import base64
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from nfv_tempest_plugin.tests.scenario.network_exporter import (
+    net_vf_metrics_mixin)
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger("{} [-] nfv_plugin_test".format(__name__))
+
+
+class TestSriovVfMetrics(net_vf_metrics_mixin.NetVfMetricsMixin,
+                         metrics_base.NetworkExporterMetricsBase):
+    """Validate SR-IOV VF metrics presence, labels, and traffic movement."""
+
+    TEST_NAME = 'network_exporter_sriov_vf_metrics'
+
+    def _sriov_ports_filter(self):
+        """Match TestSriovScenarios: attach external (SSH/FIP) + direct SR-IOV."""
+        physnet = CONF.nfv_plugin_options.network_exporter_sriov_physnet.strip()
+        return "external,direct:%s" % physnet if physnet else "external,direct"
+
+    def _ensure_test_setup(self):
+        """Default test config when tests-setup omits this test name."""
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_sriov_test_networks(self, test_networks):
+        """Create mgmt + external + direct ports (same pattern as SR-IOV use cases).
+
+        Keeps provider/external networks for SSH and floating IP access via
+        ports_filter external,direct[:physnet]. Skips unrelated networks (e.g.
+        DPDK-only) to avoid unnecessary port creation.
+        """
+        physnet = CONF.nfv_plugin_options.network_exporter_sriov_physnet.strip()
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('tag') == 'external':
+                filtered.append(network)
+                continue
+            if network.get('port_type') != 'direct':
+                continue
+            if physnet and network.get('physical_network') != physnet:
+                continue
+            filtered.append(network)
+        if not any(net.get('port_type') == 'direct' for net in filtered):
+            raise unittest.SkipTest(
+                'No direct SR-IOV test-network in tempest_config.yml for '
+                '%s. Add a test-network with port_type: direct and '
+                'physical_network matching Neutron (set '
+                'network_exporter_sriov_physnet to select one physnet).' %
+                self.TEST_NAME)
+        LOG.warning(
+            'SR-IOV VF metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_sriov_boot_kwargs(self):
+        """Resource kwargs aligned with test_nfv_sriov_usecases boot pattern."""
+        ports_filter = self._sriov_ports_filter()
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _collect_vm_ports(self, servers):
+        by_server = {}
+        for server in servers:
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server["id"])["ports"]
+            by_server[server["id"]] = ports
+        return by_server
+
+    def _sriov_port_by_server(self, servers):
+        ports_by_server = self._collect_vm_ports(servers)
+        server_ports = {}
+        for server in servers:
+            direct_ports = [
+                port for port in ports_by_server[server["id"]]
+                if (port.get("binding:vnic_type") == "direct" and
+                    port.get("fixed_ips"))
+            ]
+            if direct_ports:
+                server_ports[server["id"]] = direct_ports
+        return server_ports
+
+    def _select_peer_ports(self, servers):
+        ports_by_server = self._sriov_port_by_server(servers)
+        if len(ports_by_server) < 2:
+            raise unittest.SkipTest(
+                "SR-IOV VF metrics test needs at least two VMs with direct "
+                "ports attached. Set network_exporter_sriov_physnet or "
+                "adjust test resources.")
+        for sender in servers:
+            sender_ports = ports_by_server.get(sender["id"], [])
+            for receiver in servers:
+                if receiver["id"] == sender["id"]:
+                    continue
+                receiver_ports = ports_by_server.get(receiver["id"], [])
+                for sender_port in sender_ports:
+                    for receiver_port in receiver_ports:
+                        if (sender_port["network_id"] ==
+                                receiver_port["network_id"]):
+                            return (sender, sender_port, receiver,
+                                    receiver_port)
+        raise unittest.SkipTest(
+            "No shared SR-IOV direct network between test VMs. Check that "
+            "test resources provide at least one common direct network.")
+
+    def _ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_sriov_traffic_ping_count
+
+    def _min_expected_packets_for_count(self, count):
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_sriov_counter_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _min_expected_packets(self):
+        return self._min_expected_packets_for_count(self._ping_count())
+
+    def _min_expected_bytes(self):
+        return (self._min_expected_packets() *
+                CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
+
+    def _min_expected_bytes_for_count(self, packet_count):
+        return (self._min_expected_packets_for_count(packet_count) *
+                CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
+
+    def _boot_sriov_vms(self):
+        """Create networks, ports, flavor (if configured), and boot two VMs."""
+        self._ensure_test_setup()
+        boot_kwargs = self._build_sriov_boot_kwargs()
+        LOG.warning(
+            'Booting SR-IOV VMs for %s with ports_filter=%s',
+            self.TEST_NAME, boot_kwargs['srv_details'][0]['ports_filter'])
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = self._filter_sriov_test_networks(
+            full_test_networks)
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _subnet_broadcast_ip(self, ip_address):
+        """Return IPv4 subnet broadcast address for ip_address, or None."""
+        if ':' in ip_address:
+            return None
+        octets = ip_address.split('.')
+        if len(octets) != 4:
+            return None
+        return '.'.join(octets[:3] + ['255'])
+
+    def _build_traffic_context(self):
+        """Boot SR-IOV peer VMs and return sender/receiver dataplane context."""
+        servers, key_pair = self._boot_sriov_vms()
+        sender, sender_port, receiver, receiver_port = self._select_peer_ports(
+            servers)
+        sender_ctx = {
+            "server": sender,
+            "port": sender_port,
+            "hypervisor_ip": sender["hypervisor_ip"],
+            "vf_labels": self._vf_labels_from_mac(
+                sender["hypervisor_ip"], sender_port["mac_address"]),
+        }
+        receiver_ctx = {
+            "server": receiver,
+            "port": receiver_port,
+            "hypervisor_ip": receiver["hypervisor_ip"],
+            "vf_labels": self._vf_labels_from_mac(
+                receiver["hypervisor_ip"], receiver_port["mac_address"]),
+        }
+        peer_ip = receiver_port["fixed_ips"][0]["ip_address"]
+        ip_for_access = sender.get('fip') or sender.get('fixed_ip')
+        ssh_sender = self.get_remote_client(
+            ip_for_access, self.instance_user, key_pair["private_key"])
+        receiver_access_ip = receiver.get('fip') or receiver.get('fixed_ip')
+        ssh_receiver = self.get_remote_client(
+            receiver_access_ip, self.instance_user, key_pair["private_key"])
+        return {
+            "sender": sender_ctx,
+            "receiver": receiver_ctx,
+            "ssh_sender": ssh_sender,
+            "ssh_receiver": ssh_receiver,
+            "peer_ip": peer_ip,
+            "broadcast_ip": self._subnet_broadcast_ip(peer_ip),
+        }
+
+    def _send_multicast_packets(self, ctx, count, min_packets):
+        """Send IPv4 UDP multicast on the SR-IOV L2 segment (no listener)."""
+        bind_ip = ctx['sender']['port']['fixed_ips'][0]['ip_address']
+        if ':' in bind_ip:
+            raise unittest.SkipTest(
+                'Multicast VF metric test needs an IPv4 SR-IOV sender address')
+        group = '224.0.0.1'
+        flood_count = (
+            CONF.nfv_plugin_options.network_exporter_sriov_multicast_flood_packets)
+        LOG.warning(
+            'Sending multicast UDP: %d datagrams to %s:9997 from %s',
+            flood_count, group, bind_ip)
+        script = (
+            'import socket\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            's.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 32)\n'
+            's.bind((%r, 0))\n'
+            'dest = (%r, 9997)\n'
+            'payload = b"x" * 64\n'
+            'for _ in range(%d):\n'
+            '    s.sendto(payload, dest)\n'
+            % (bind_ip, group, flood_count))
+        self._run_guest_python_script(ctx['ssh_sender'], script, timeout_sec=120)
+
+    def _send_broadcast_packets(self, ctx, count, min_packets):
+        """Send IPv4 UDP broadcast on the SR-IOV L2 segment (no reply needed)."""
+        broadcast_ip = ctx.get('broadcast_ip')
+        if not broadcast_ip:
+            raise unittest.SkipTest(
+                'Broadcast VF metric test needs an IPv4 SR-IOV peer address')
+        flood_count = (
+            CONF.nfv_plugin_options.network_exporter_sriov_broadcast_flood_packets)
+        bind_ip = ctx['sender']['port']['fixed_ips'][0]['ip_address']
+        LOG.warning(
+            'Sending broadcast UDP: %d datagrams to %s:9998 from %s',
+            flood_count, broadcast_ip, bind_ip)
+        self._flood_udp_dataplane(
+            ctx['ssh_sender'], bind_ip, broadcast_ip, flood_count,
+            broadcast=True)
+
+    def _guest_sudo_prefix(self, ssh_client):
+        """Return sudo prefix when passwordless sudo is available on the guest."""
+        if self._guest_has_passwordless_sudo(ssh_client):
+            return 'sudo -n'
+        return ''
+
+    def _set_hypervisor_vf_link_state(self, hypervisor_ip, vf_labels, enabled):
+        """Enable or disable SR-IOV VF link state from the compute hypervisor."""
+        state = 'enable' if enabled else 'disable'
+        cmd = 'sudo ip link set dev %s vf %s state %s' % (
+            vf_labels['device'], vf_labels['vf'], state)
+        self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
+
+    def _restore_hypervisor_vf_link(self, hypervisor_ip, vf_labels):
+        """Best-effort re-enable of VF link state after transmit drop test."""
+        self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo ip link set dev %s vf %s state enable' % (
+                vf_labels['device'], vf_labels['vf']))
+
+    def _induce_transmit_drops(self, ctx, count, min_packets):
+        """Disable host VF link and flood TX from guest (iface stays up)."""
+        sender = ctx['sender']
+        hypervisor_ip = sender['hypervisor_ip']
+        vf_labels = sender['vf_labels']
+        mac_address = sender['port']['mac_address']
+        bind_ip = sender['port']['fixed_ips'][0]['ip_address']
+        peer_ip = ctx['peer_ip']
+        ssh_sender = ctx['ssh_sender']
+        flood_count = (
+            CONF.nfv_plugin_options.network_exporter_sriov_tx_drop_flood_packets)
+
+        self.addCleanup(
+            self._restore_hypervisor_vf_link, hypervisor_ip, vf_labels)
+        self._maybe_shrink_guest_tx_ring(ssh_sender, mac_address)
+        self._set_hypervisor_vf_link_state(
+            hypervisor_ip, vf_labels, False)
+        time.sleep(2)
+
+        sysfs_before = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, 'tx_dropped')
+        LOG.warning(
+            'Inducing transmit drops on %s VF %s: host link disabled, '
+            'guest iface up, %d UDP datagrams %s -> %s (sysfs tx_dropped=%s)',
+            hypervisor_ip, vf_labels, flood_count, bind_ip, peer_ip,
+            sysfs_before)
+        self._flood_udp_dataplane(
+            ssh_sender, bind_ip, peer_ip, flood_count)
+        self._restore_hypervisor_vf_link(hypervisor_ip, vf_labels)
+        sysfs_after = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, 'tx_dropped')
+        LOG.warning(
+            'Transmit drop induce finished on %s VF %s: sysfs tx_dropped '
+            'before=%s after=%s',
+            hypervisor_ip, vf_labels, sysfs_before, sysfs_after)
+        ctx['sysfs_drop_before'] = sysfs_before
+        ctx['sysfs_drop_after'] = sysfs_after
+
+    def _run_guest_python_script(self, ssh_client, script, timeout_sec=60):
+        """Run a Python script on the guest via base64 pipe (avoids quoting)."""
+        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
+        cmd = 'timeout %d sh -c \'echo %s | base64 -d | python3\'' % (
+            timeout_sec, encoded)
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if sudo:
+            cmd = '%s %s' % (sudo, cmd)
+        return ssh_client.exec_command(cmd)
+
+    def _maybe_shrink_guest_rx_ring(self, ssh_client, mac_address):
+        """Temporarily shrink RX ring on guest SR-IOV NIC to ease RX drops."""
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if not sudo:
+            return None
+        iface = self._guest_dataplane_iface(ssh_client, mac_address)
+        ssh_client.exec_command(
+            '%s ethtool -G %s rx 32 2>/dev/null || '
+            '%s ethtool -G %s rx 64 2>/dev/null || true' % (
+                sudo, iface, sudo, iface))
+
+        def restore():
+            ssh_client.exec_command(
+                '%s ethtool -G %s rx 512 2>/dev/null || true' % (
+                    sudo, iface))
+
+        self.addCleanup(restore)
+        return iface
+
+    def _maybe_shrink_guest_tx_ring(self, ssh_client, mac_address):
+        """Temporarily shrink TX ring on guest SR-IOV NIC to ease TX drops."""
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if not sudo:
+            return None
+        iface = self._guest_dataplane_iface(ssh_client, mac_address)
+        ssh_client.exec_command(
+            '%s ethtool -G %s tx 32 2>/dev/null || '
+            '%s ethtool -G %s tx 64 2>/dev/null || true' % (
+                sudo, iface, sudo, iface))
+
+        def restore():
+            ssh_client.exec_command(
+                '%s ethtool -G %s tx 512 2>/dev/null || true' % (
+                    sudo, iface))
+
+        self.addCleanup(restore)
+        return iface
+
+    def _flood_udp_dataplane(self, ssh_client, bind_ip, dest_ip, packet_count,
+                             broadcast=False):
+        """Send a UDP flood bound to the SR-IOV guest IP."""
+        bcast = 'True' if broadcast else 'False'
+        script = (
+            'import socket\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            'if %s:\n'
+            '    s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)\n'
+            's.bind((%r, 0))\n'
+            'payload = b"x" * 1400\n'
+            'dest = (%r, 9999)\n'
+            'for _ in range(%d):\n'
+            '    try:\n'
+            '        s.sendto(payload, dest)\n'
+            '    except OSError:\n'
+            '        pass\n'
+            % (bcast, bind_ip, dest_ip, packet_count))
+        self._run_guest_python_script(ssh_client, script, timeout_sec=120)
+
+    def _induce_receive_drops(self, ctx, count, min_packets):
+        """Shrink RX ring and flood peer IP to overflow the receiver VF."""
+        if ':' in ctx['peer_ip']:
+            raise unittest.SkipTest(
+                'RX drop flood test currently supports IPv4 SR-IOV peers only')
+        receiver = ctx['receiver']
+        hypervisor_ip = receiver['hypervisor_ip']
+        vf_labels = receiver['vf_labels']
+        bind_ip = ctx['sender']['port']['fixed_ips'][0]['ip_address']
+        flood_count = (
+            CONF.nfv_plugin_options.network_exporter_sriov_rx_drop_flood_packets)
+        self._maybe_shrink_guest_rx_ring(
+            ctx['ssh_receiver'], receiver['port']['mac_address'])
+
+        sysfs_before = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, 'rx_dropped')
+        LOG.warning(
+            'Inducing receive drops on %s VF %s: %d UDP datagrams %s -> %s '
+            'with no listener (sysfs rx_dropped=%s)',
+            hypervisor_ip, vf_labels, flood_count, bind_ip, ctx['peer_ip'],
+            sysfs_before)
+        self._flood_udp_dataplane(
+            ctx['ssh_sender'], bind_ip, ctx['peer_ip'], flood_count)
+        sysfs_after = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, 'rx_dropped')
+        LOG.warning(
+            'Receive drop induce finished on %s VF %s: sysfs rx_dropped '
+            'before=%s after=%s',
+            hypervisor_ip, vf_labels, sysfs_before, sysfs_after)
+        ctx['sysfs_drop_before'] = sysfs_before
+        ctx['sysfs_drop_after'] = sysfs_after
+
+    # --- Presence: one Tempest result per net_vf metric family ---
+
+    def test_net_vf_info_reported(self):
+        """Verify net_vf_info on compute :9105 and metric-storage Prometheus."""
+        self._assert_net_vf_metric_reported(metrics_base.NET_VF_INFO_METRIC)
+
+    def test_net_vf_receive_packets_total_reported(self):
+        """Verify net_vf_receive_packets_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_RECEIVE_PACKETS_METRIC)
+
+    def test_net_vf_transmit_packets_total_reported(self):
+        """Verify net_vf_transmit_packets_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_TRANSMIT_PACKETS_METRIC)
+
+    def test_net_vf_receive_bytes_total_reported(self):
+        """Verify net_vf_receive_bytes_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_RECEIVE_BYTES_METRIC)
+
+    def test_net_vf_transmit_bytes_total_reported(self):
+        """Verify net_vf_transmit_bytes_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_TRANSMIT_BYTES_METRIC)
+
+    def test_net_vf_broadcast_packets_total_reported(self):
+        """Verify net_vf_broadcast_packets_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_BROADCAST_PACKETS_METRIC)
+
+    def test_net_vf_multicast_packets_total_reported(self):
+        """Verify net_vf_multicast_packets_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_MULTICAST_PACKETS_METRIC)
+
+    # --- Label integrity (net_vf_info only) ---
+
+    def test_net_vf_info_labels_match_host(self):
+        """Verify net_vf_info labels match host VF mapping for VM direct ports."""
+        self._assert_net_vf_metric_reported(metrics_base.NET_VF_INFO_METRIC)
+        servers, _ = self._boot_sriov_vms()
+        sender, sender_port, receiver, receiver_port = self._select_peer_ports(
+            servers)
+        for server, port in ((sender, sender_port), (receiver, receiver_port)):
+            hypervisor_ip = server["hypervisor_ip"]
+            expected_labels = self._vf_labels_from_mac(
+                hypervisor_ip, port["mac_address"])
+            samples = self._prom_samples(
+                hypervisor_ip, metrics_base.NET_VF_INFO_METRIC,
+                required_labels={
+                    "device": expected_labels["device"],
+                    "vf": expected_labels["vf"],
+                    "pci_address": expected_labels["pci_address"],
+                })
+            self.assertNotEmpty(
+                samples,
+                "No net_vf_info sample found on %s for labels %s "
+                "(MAC=%s, server=%s)" % (
+                    hypervisor_ip, expected_labels,
+                    port["mac_address"], server["id"]))
+            exported_numa_nodes = {
+                sample["labels"].get("numa_node", "") for sample in samples}
+            self.assertIn(
+                expected_labels["numa_node"], exported_numa_nodes,
+                "numa_node mismatch for host VF labels %s on %s. "
+                "Exporter returned numa_node values %s" % (
+                    expected_labels, hypervisor_ip,
+                    sorted(exported_numa_nodes)))
+            self._assert_net_vf_metrics_match_metric_storage(
+                hypervisor_ip, metrics_base.NET_VF_INFO_METRIC, {
+                    'device': expected_labels['device'],
+                    'vf': expected_labels['vf'],
+                    'pci_address': expected_labels['pci_address'],
+                })
+
+    def test_net_vf_guest_dataplane_mac_matches_port(self):
+        """Verify each VM SR-IOV dataplane NIC MAC matches its Neutron port."""
+        servers, key_pair = self._boot_sriov_vms()
+        sender, sender_port, receiver, receiver_port = self._select_peer_ports(
+            servers)
+        for server, port in ((sender, sender_port), (receiver, receiver_port)):
+            access_ip = server.get('fip') or server.get('fixed_ip')
+            ssh_client = self.get_remote_client(
+                access_ip, self.instance_user, key_pair['private_key'])
+            self._assert_guest_port_mac(ssh_client, port, server)
+
+    def test_net_vf_guest_dataplane_mac_not_zero(self):
+        """Verify each VM SR-IOV dataplane NIC MAC is not all zeros."""
+        servers, key_pair = self._boot_sriov_vms()
+        sender, sender_port, receiver, receiver_port = self._select_peer_ports(
+            servers)
+        for server, port in ((sender, sender_port), (receiver, receiver_port)):
+            access_ip = server.get('fip') or server.get('fixed_ip')
+            ssh_client = self.get_remote_client(
+                access_ip, self.instance_user, key_pair['private_key'])
+            self._assert_guest_port_mac_not_zero(ssh_client, port, server)
+
+    # --- Traffic: one Tempest result per counter metric ---
+
+    def test_net_vf_transmit_packets_total_increases_with_traffic(self):
+        """Verify net_vf_transmit_packets_total increases on sender VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_TRANSMIT_PACKETS_METRIC, 'sender', 'packets')
+
+    def test_net_vf_receive_packets_total_increases_with_traffic(self):
+        """Verify net_vf_receive_packets_total increases on receiver VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_RECEIVE_PACKETS_METRIC, 'receiver', 'packets')
+
+    def test_net_vf_transmit_bytes_total_increases_with_traffic(self):
+        """Verify net_vf_transmit_bytes_total increases on sender VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_TRANSMIT_BYTES_METRIC, 'sender', 'bytes')
+
+    def test_net_vf_receive_bytes_total_increases_with_traffic(self):
+        """Verify net_vf_receive_bytes_total increases on receiver VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_RECEIVE_BYTES_METRIC, 'receiver', 'bytes')
+
+    def test_net_vf_multicast_packets_total_increases_with_traffic(self):
+        """Verify net_vf_multicast_packets_total increases on receiver VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_MULTICAST_PACKETS_METRIC, 'receiver',
+            'packets', traffic_generator=self._send_multicast_packets,
+            traffic_packet_count=CONF.nfv_plugin_options.
+            network_exporter_sriov_multicast_flood_packets)
+
+    def test_net_vf_broadcast_packets_total_increases_with_traffic(self):
+        """Verify net_vf_broadcast_packets_total increases on receiver VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_BROADCAST_PACKETS_METRIC, 'receiver',
+            'packets', traffic_generator=self._send_broadcast_packets,
+            traffic_packet_count=CONF.nfv_plugin_options.
+            network_exporter_sriov_broadcast_flood_packets)
+
+    # --- Drop counters (test_z_* runs last; do not use a TestCase subclass
+    #     for ordering — unittest re-discovers inherited test_* methods) ---
+
+    def test_z_net_vf_receive_dropped_total_reported(self):
+        """Verify net_vf_receive_dropped_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_RECEIVE_DROPPED_METRIC)
+
+    def test_z_net_vf_transmit_dropped_total_reported(self):
+        """Verify net_vf_transmit_dropped_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_TRANSMIT_DROPPED_METRIC)
+
+    def test_z_net_vf_transmit_dropped_total_increases_with_traffic(self):
+        """Verify net_vf_transmit_dropped_total increases after TX link-down."""
+        self._test_vf_drop_counter_increases(
+            metrics_base.NET_VF_TRANSMIT_DROPPED_METRIC, 'sender',
+            traffic_generator=self._induce_transmit_drops,
+            sysfs_stat_name='tx_dropped')
+
+    def test_z_net_vf_receive_dropped_total_increases_with_traffic(self):
+        """Verify net_vf_receive_dropped_total increases after RX UDP flood."""
+        self._test_vf_drop_counter_increases(
+            metrics_base.NET_VF_RECEIVE_DROPPED_METRIC, 'receiver',
+            traffic_generator=self._induce_receive_drops,
+            sysfs_stat_name='rx_dropped')


### PR DESCRIPTION
Add TestSriovVfMetrics covering all net_vf_* exporter metrics: presence
    on compute :9105 and metric-storage Prometheus, per-VF label integrity,
    guest dataplane MAC checks, traffic-driven counter growth (ping,
    multicast, broadcast), and TX/RX drop counter validation.
    
    Boot two SR-IOV peer VMs with mgmt + direct ports, map VFs by MAC, and
    validate counters against host sysfs where available. Compare live
    :9105 scrapes with metric-storage PromQL for the same (device, vf,
    pci_address) on every test.
    
    TX drops: disable host VF link, keep guest iface up, shrink TX ring,
    flood UDP from the sender. RX drops: shrink RX ring and flood peer IP
    with no listener. Extract reusable validation helpers into
    net_vf_metrics_mixin.py.
    
    Config: network_exporter_sriov_physnet, traffic/drop flood packet counts,
    counter tolerance.
