### PR TITLE
Fixing vf parsing

### DIFF
--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -67,15 +67,15 @@ test-networks:
     network_type: vlan
     ip_version: 4
     port_type: direct
-    # Nova will set the binding profile of this port to trusted=true and will
-    # set it as Trusted VF
-    trusted_vf: true
-    # set if using HW-Offload port when OVS in is in switchdev mode
-    switchdev: true
-    # set on SRIOV nics support.
-    min_qos: true
-    # (Optional) - Do not attach the network to the instance by default
-    skip_srv_attach: true
+    # network_exporter_sriov_vf_metrics: set skip_srv_attach false (or omit).
+    # Do not set trusted_vf/switchdev unless your Nova PCI whitelist requires them.
+
+# Per-test flavor/image selection (optional). When omitted, compute.flavor_ref is used.
+# network_exporter_sriov_vf_metrics also needs a direct test-network (see above) and
+# [nfv_plugin_options] network_exporter_sriov_physnet matching its physical_network.
+tests-setup:
+  - name: network_exporter_sriov_vf_metrics
+    flavor: nfv_qe_base_flavor
 
 # Flavors used by the test.
 # Will be created by the tests during the execution

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -94,6 +94,8 @@ test-networks:
 # network_exporter_datapath_flow and network_exporter_datapath_lookup use the same
 # network layout as network_exporter_generic_traffic (mgmt + normal dataplane).
 # Guests need passwordless sudo for full ICMP flood (network_exporter_traffic_ping_count).
+# network_exporter_pmd_iterations and network_exporter_pmd_packets require DPDK-enabled
+# computes (pmd-perf-show). Same network layout as network_exporter_generic_traffic.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor
@@ -106,6 +108,10 @@ tests-setup:
   - name: network_exporter_datapath_flow
     flavor: nfv_qe_base_flavor
   - name: network_exporter_datapath_lookup
+    flavor: nfv_qe_base_flavor
+  - name: network_exporter_pmd_iterations
+    flavor: nfv_qe_base_flavor
+  - name: network_exporter_pmd_packets
     flavor: nfv_qe_base_flavor
 
 # Flavors used by the test.

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -80,10 +80,20 @@ test-networks:
 # uses L2); this avoids Neutron BadRequest when multiple subnets share a CIDR.
 # Guests need passwordless sudo for fast ICMP (network_exporter_traffic_ping_count
 # defaults to 5000); otherwise lower the ping count or grant sudo in the guest image.
+# network_exporter_ovs_interface_errors uses the same network layout as generic
+# traffic (mgmt + one shared normal dataplane net) and passwordless sudo for UDP
+# flood / ping during error induce.
+# network_exporter_router_traffic needs mgmt plus at least one other normal
+# test-network with a distinct CIDR; both subnets are attached to the Neutron
+# router (test_networks_only). Cross-subnet ICMP drives ovnc_router_port_traffic_*.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor
   - name: network_exporter_generic_traffic
+    flavor: nfv_qe_base_flavor
+  - name: network_exporter_ovs_interface_errors
+    flavor: nfv_qe_base_flavor
+  - name: network_exporter_router_traffic
     flavor: nfv_qe_base_flavor
 
 # Flavors used by the test.

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -91,6 +91,9 @@ test-networks:
 # (default 50%%) and network_exporter_router_traffic_min_packets (default 400).
 # Counter expectation also scales to network_exporter_router_traffic_metric_scale_pct
 # (default 28%%) of transmitted probes.
+# network_exporter_datapath_flow and network_exporter_datapath_lookup use the same
+# network layout as network_exporter_generic_traffic (mgmt + normal dataplane).
+# Guests need passwordless sudo for full ICMP flood (network_exporter_traffic_ping_count).
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor
@@ -99,6 +102,10 @@ tests-setup:
   - name: network_exporter_ovs_interface_errors
     flavor: nfv_qe_base_flavor
   - name: network_exporter_router_traffic
+    flavor: nfv_qe_base_flavor
+  - name: network_exporter_datapath_flow
+    flavor: nfv_qe_base_flavor
+  - name: network_exporter_datapath_lookup
     flavor: nfv_qe_base_flavor
 
 # Flavors used by the test.

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -89,7 +89,8 @@ test-networks:
 # sec_groups: true is applied on every normal/mgmt router test-network automatically.
 # Router counter deltas use network_exporter_router_traffic_packet_tolerance_pct
 # (default 50%%) and network_exporter_router_traffic_min_packets (default 400).
-# Traffic is only sent on ICMP probe-verified cross-subnet pairs.
+# Counter expectation also scales to network_exporter_router_traffic_metric_scale_pct
+# (default 28%%) of transmitted probes.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -98,6 +98,8 @@ test-networks:
 # computes (pmd-perf-show). Same network layout as network_exporter_generic_traffic.
 # network_exporter_pmd_cpu_usage validates ovs_pmd_cpu_overhead and ovs_pmd_rxq_usage
 # via pmd-rxq-show on DPDK computes.
+# network_exporter memory tests (test_ovs_memory_metrics) need DPDK/OVS computes with
+# perf metrics enabled on :9105; no tests-setup entry is required.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -86,6 +86,8 @@ test-networks:
 # network_exporter_router_traffic needs mgmt plus at least one other normal
 # test-network with a distinct CIDR; both subnets are attached to the Neutron
 # router (test_networks_only). Cross-subnet ICMP drives ovnc_router_port_traffic_*.
+# Router counter deltas use network_exporter_router_traffic_packet_tolerance_pct
+# (default 50%%) because metric-storage reflects fewer packets than ICMP sent.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -96,6 +96,8 @@ test-networks:
 # Guests need passwordless sudo for full ICMP flood (network_exporter_traffic_ping_count).
 # network_exporter_pmd_iterations and network_exporter_pmd_packets require DPDK-enabled
 # computes (pmd-perf-show). Same network layout as network_exporter_generic_traffic.
+# network_exporter_pmd_cpu_usage validates ovs_pmd_cpu_overhead and ovs_pmd_rxq_usage
+# via pmd-rxq-show on DPDK computes.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor
@@ -112,6 +114,8 @@ tests-setup:
   - name: network_exporter_pmd_iterations
     flavor: nfv_qe_base_flavor
   - name: network_exporter_pmd_packets
+    flavor: nfv_qe_base_flavor
+  - name: network_exporter_pmd_cpu_usage
     flavor: nfv_qe_base_flavor
 
 # Flavors used by the test.

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -87,7 +87,8 @@ test-networks:
 # test-network with a distinct CIDR; both subnets are attached to the Neutron
 # router (test_networks_only). Cross-subnet ICMP drives ovnc_router_port_traffic_*.
 # Router counter deltas use network_exporter_router_traffic_packet_tolerance_pct
-# (default 50%%) because metric-storage reflects fewer packets than ICMP sent.
+# (default 50%%) and network_exporter_router_traffic_min_packets (default 400).
+# Traffic is only sent on ICMP probe-verified cross-subnet pairs.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -86,6 +86,7 @@ test-networks:
 # network_exporter_router_traffic needs mgmt plus at least one other normal
 # test-network with a distinct CIDR; both subnets are attached to the Neutron
 # router (test_networks_only). Cross-subnet ICMP drives ovnc_router_port_traffic_*.
+# sec_groups: true is applied on every normal/mgmt router test-network automatically.
 # Router counter deltas use network_exporter_router_traffic_packet_tolerance_pct
 # (default 50%%) and network_exporter_router_traffic_min_packets (default 400).
 # Traffic is only sent on ICMP probe-verified cross-subnet pairs.

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -100,6 +100,9 @@ test-networks:
 # via pmd-rxq-show on DPDK computes.
 # network_exporter memory tests (test_ovs_memory_metrics) need DPDK/OVS computes with
 # perf metrics enabled on :9105; no tests-setup entry is required.
+# network_exporter OVN controller tests (test_ovnc_config_metrics,
+# test_ovnc_txn_metrics) need OVN :1981 on computes; txn counters require DEBUG
+# and ERRORS metric sets on network-exporter; no tests-setup entry is required.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -75,10 +75,11 @@ test-networks:
 # [nfv_plugin_options] network_exporter_sriov_physnet matching its physical_network.
 # network_exporter_generic_traffic boots two VMs on a shared provider network (mgmt plus
 # at least one non-SR-IOV dataplane network with L2/L3 connectivity between them,
-# typically port_type: normal such as vlan1500 above). No direct port or
-# network_exporter_sriov_physnet is required. Guests need passwordless sudo for fast
-# ICMP (network_exporter_traffic_ping_count defaults to 5000); otherwise lower the
-# ping count or grant sudo in the guest image.
+# typically port_type: normal such as vlan1500 above). Direct (SR-IOV) test-networks
+# are skipped automatically. Only the mgmt subnet is attached to the router (dataplane
+# uses L2); this avoids Neutron BadRequest when multiple subnets share a CIDR.
+# Guests need passwordless sudo for fast ICMP (network_exporter_traffic_ping_count
+# defaults to 5000); otherwise lower the ping count or grant sudo in the guest image.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
     flavor: nfv_qe_base_flavor

--- a/docs/tempest_config.yml.sample
+++ b/docs/tempest_config.yml.sample
@@ -73,8 +73,16 @@ test-networks:
 # Per-test flavor/image selection (optional). When omitted, compute.flavor_ref is used.
 # network_exporter_sriov_vf_metrics also needs a direct test-network (see above) and
 # [nfv_plugin_options] network_exporter_sriov_physnet matching its physical_network.
+# network_exporter_generic_traffic boots two VMs on a shared provider network (mgmt plus
+# at least one non-SR-IOV dataplane network with L2/L3 connectivity between them,
+# typically port_type: normal such as vlan1500 above). No direct port or
+# network_exporter_sriov_physnet is required. Guests need passwordless sudo for fast
+# ICMP (network_exporter_traffic_ping_count defaults to 5000); otherwise lower the
+# ping count or grant sudo in the guest image.
 tests-setup:
   - name: network_exporter_sriov_vf_metrics
+    flavor: nfv_qe_base_flavor
+  - name: network_exporter_generic_traffic
     flavor: nfv_qe_base_flavor
 
 # Flavors used by the test.

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -117,6 +117,53 @@ NfvPluginOptions = [
                help='OVS/kernel netdev for the state-test veth (max 15 characters; '
                     'Linux IFNAMSIZ). Host peer is <name> with a -h suffix when '
                     'that fits, otherwise tpst-ovs-pe.'),
+    cfg.IntOpt('network_exporter_traffic_min_bytes_per_packet',
+               default=64,
+               help='Minimum expected byte delta per counted packet when '
+                    'validating tx/rx_bytes increases.'),
+    cfg.StrOpt('network_exporter_sriov_physnet',
+               default='',
+               help='SR-IOV physnet name from tempest_config.yml test-networks '
+                    '(port_type: direct). When set, only that physnet is created '
+                    'for VM boot and ports_filter uses external,direct:<physnet>. '
+                    'Requires test-networks with mgmt, tag: external, and direct '
+                    'port_type. Must match a physical_network known to Neutron ML2.'),
+    cfg.IntOpt('network_exporter_sriov_traffic_ping_count',
+               default=150,
+               help='ICMP echo requests sent between SR-IOV guests for '
+                    'net_vf_receive/transmit_{packets,bytes}_total checks. '
+                    'Without passwordless sudo on the guest, unprivileged ping '
+                    'is limited to 200ms interval (~120s wall clock for 600 '
+                    'packets).'),
+    cfg.IntOpt('network_exporter_sriov_counter_tolerance_pct',
+               default=20,
+               help='Allowed shortfall (percent) versus '
+                    'network_exporter_sriov_traffic_ping_count when checking '
+                    'SR-IOV VF packet/byte counter growth.'),
+    cfg.IntOpt('network_exporter_sriov_rx_drop_flood_packets',
+               default=50000,
+               help='UDP datagrams sent at high rate to the SR-IOV peer IP '
+                    'without a receiver, to induce net_vf_receive_dropped_total '
+                    'increases on the receiver VF.'),
+    cfg.IntOpt('network_exporter_sriov_tx_drop_flood_packets',
+               default=10000,
+               help='UDP datagrams sent from the SR-IOV guest while the host '
+                    'VF link is disabled, to induce net_vf_transmit_dropped_total '
+                    'increases on the sender VF.'),
+    cfg.IntOpt('network_exporter_sriov_broadcast_flood_packets',
+               default=150,
+               help='UDP datagrams sent to the SR-IOV subnet broadcast address '
+                    'to drive net_vf_broadcast_packets_total on the receiver '
+                    'VF. Uses SO_BROADCAST (not ping -b) because many direct '
+                    'SR-IOV segments do not answer broadcast ICMP.'),
+    cfg.IntOpt('network_exporter_sriov_multicast_flood_packets',
+               default=150,
+               help='UDP datagrams sent to 224.0.0.1 on the SR-IOV dataplane '
+                    '(bound to the sender guest IP) to drive '
+                    'net_vf_multicast_packets_total on the receiver VF. '
+                    'Does not rely on a guest socket listener; L2 multicast '
+                    'flooding on the direct segment is enough for the NIC '
+                    'counter.'),
     cfg.BoolOpt('use_neutron_api_v2',
                 default=False,
                 help="Use neutron-tempest-plugin clients"),

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -130,6 +130,13 @@ NfvPluginOptions = [
                default=64,
                help='Minimum expected byte delta per counted packet when '
                     'validating tx/rx_bytes increases.'),
+    cfg.IntOpt('network_exporter_router_traffic_packet_tolerance_pct',
+               default=50,
+               help='Allowed shortfall (percent) versus '
+                    'network_exporter_traffic_ping_count when comparing '
+                    'ovnc_router_port_traffic_* deltas. Router port counters '
+                    'fed through metric-storage typically reflect roughly half '
+                    'of the ICMP probes sent cross-subnet.'),
     cfg.IntOpt('network_exporter_error_udp_flood_packets',
                default=50000,
                help='UDP datagrams sent at high rate to a peer dataplane IP '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -186,9 +186,10 @@ NfvPluginOptions = [
                       'pmd-rxq-show and live :9105 for ovs_pmd_cpu_overhead '
                       'and ovs_pmd_rxq_usage gauges.'),
     cfg.FloatOpt('network_exporter_pmd_min_rxq_usage_pct',
-                 default=1.0,
-                 help='Minimum ovs_pmd_rxq_usage peak after VM traffic on at '
-                      'least one enabled RxQ.'),
+                 default=0.0,
+                 help='When >0, require this ovs_pmd_rxq_usage peak after VM '
+                      'traffic. When 0, traffic activity is validated via '
+                      'ovs_pmd_busy_iterations or ovs_pmd_rx_packets instead.'),
     cfg.IntOpt('network_exporter_error_udp_flood_packets',
                default=50000,
                help='UDP datagrams sent at high rate to a peer dataplane IP '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -130,6 +130,11 @@ NfvPluginOptions = [
                default=64,
                help='Minimum expected byte delta per counted packet when '
                     'validating tx/rx_bytes increases.'),
+    cfg.IntOpt('network_exporter_error_udp_flood_packets',
+               default=50000,
+               help='UDP datagrams sent at high rate to a peer dataplane IP '
+                    'without a listener, to induce ovs_interface_rx_dropped '
+                    'increases on the receiver OVS port.'),
     cfg.StrOpt('network_exporter_sriov_physnet',
                default='',
                help='SR-IOV physnet name from tempest_config.yml test-networks '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -148,8 +148,12 @@ NfvPluginOptions = [
                     'typically reflects well under half of routed ICMP).'),
     cfg.StrOpt('network_exporter_datapath_name',
                default='ovs-system',
-               help='OVS kernel datapath name for ovs_datapath_* metrics and '
-                    'ovs-dpctl ground-truth checks.'),
+               help='OVS datapath name label for ovs_datapath_* metrics and '
+                    'ovs-appctl dpctl/show ground-truth checks.'),
+    cfg.StrOpt('network_exporter_datapath_type',
+               default='system',
+               help='OVS datapath type label (e.g. system, netdev) for '
+                    'ovs_datapath_* series selection.'),
     cfg.IntOpt('network_exporter_datapath_min_flow_increase',
                default=1,
                help='Minimum ovs_datapath_flows_total increase after VM boot '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -137,6 +137,12 @@ NfvPluginOptions = [
                     'ovnc_router_port_traffic_* deltas. Router port counters '
                     'fed through metric-storage typically reflect roughly half '
                     'of the ICMP probes sent cross-subnet.'),
+    cfg.IntOpt('network_exporter_router_traffic_min_packets',
+               default=400,
+               help='Floor for ovnc_router_port_traffic_pkts delta regardless '
+                    'of ping count/tolerance. The effective minimum is the '
+                    'lower of the tolerance-based value and ~35%% of probes '
+                    'actually transmitted on a probe-verified path.'),
     cfg.IntOpt('network_exporter_error_udp_flood_packets',
                default=50000,
                help='UDP datagrams sent at high rate to a peer dataplane IP '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -172,6 +172,14 @@ NfvPluginOptions = [
                help='Minimum summed ovs_pmd_rx/tx_packets increase after VM '
                     'traffic. 0 scales from network_exporter_traffic_ping_count '
                     'and packet tolerance.'),
+    cfg.FloatOpt('network_exporter_pmd_alignment_tolerance_pct',
+                 default=0.01,
+                 help='Allowed percent drift between pmd-perf-show and live '
+                      ':9105 when counters advance between reads.'),
+    cfg.IntOpt('network_exporter_pmd_alignment_min_delta',
+               default=5000000,
+               help='Minimum allowed absolute drift between sequential PMD '
+                    'perf-show and exporter reads.'),
     cfg.IntOpt('network_exporter_error_udp_flood_packets',
                default=50000,
                help='UDP datagrams sent at high rate to a peer dataplane IP '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -148,12 +148,13 @@ NfvPluginOptions = [
                     'typically reflects well under half of routed ICMP).'),
     cfg.StrOpt('network_exporter_datapath_name',
                default='ovs-system',
-               help='OVS datapath name label for ovs_datapath_* metrics and '
-                    'ovs-appctl dpctl/show ground-truth checks.'),
+               help='Preferred OVS datapath name label for ovs_datapath_* '
+                    'metrics. Auto-detected from exporter/dpctl/show when absent '
+                    '(e.g. ovs-netdev on DPDK computes).'),
     cfg.StrOpt('network_exporter_datapath_type',
                default='system',
-               help='OVS datapath type label (e.g. system, netdev) for '
-                    'ovs_datapath_* series selection.'),
+               help='Preferred OVS datapath type label (system or netdev). '
+                    'Auto-detected when the configured pair is absent.'),
     cfg.IntOpt('network_exporter_datapath_min_flow_increase',
                default=1,
                help='Minimum ovs_datapath_flows_total increase after VM boot '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -140,9 +140,12 @@ NfvPluginOptions = [
     cfg.IntOpt('network_exporter_router_traffic_min_packets',
                default=400,
                help='Floor for ovnc_router_port_traffic_pkts delta regardless '
-                    'of ping count/tolerance. The effective minimum is the '
-                    'lower of the tolerance-based value and ~35%% of probes '
-                    'actually transmitted on a probe-verified path.'),
+                    'of ping count/tolerance.'),
+    cfg.IntOpt('network_exporter_router_traffic_metric_scale_pct',
+               default=28,
+               help='When probes were transmitted, scale the counter '
+                    'expectation to this percent of xmit count (metric-storage '
+                    'typically reflects well under half of routed ICMP).'),
     cfg.IntOpt('network_exporter_error_udp_flood_packets',
                default=50000,
                help='UDP datagrams sent at high rate to a peer dataplane IP '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -180,6 +180,15 @@ NfvPluginOptions = [
                default=5000000,
                help='Minimum allowed absolute drift between sequential PMD '
                     'perf-show and exporter reads.'),
+    cfg.FloatOpt('network_exporter_pmd_gauge_tolerance',
+                 default=1.0,
+                 help='Allowed absolute percent-point drift between '
+                      'pmd-rxq-show and live :9105 for ovs_pmd_cpu_overhead '
+                      'and ovs_pmd_rxq_usage gauges.'),
+    cfg.FloatOpt('network_exporter_pmd_min_rxq_usage_pct',
+                 default=1.0,
+                 help='Minimum ovs_pmd_rxq_usage peak after VM traffic on at '
+                      'least one enabled RxQ.'),
     cfg.IntOpt('network_exporter_error_udp_flood_packets',
                default=50000,
                help='UDP datagrams sent at high rate to a peer dataplane IP '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -117,6 +117,15 @@ NfvPluginOptions = [
                help='OVS/kernel netdev for the state-test veth (max 15 characters; '
                     'Linux IFNAMSIZ). Host peer is <name> with a -h suffix when '
                     'that fits, otherwise tpst-ovs-pe.'),
+    cfg.IntOpt('network_exporter_traffic_ping_count',
+               default=5000,
+               help='ICMP echo requests sent between two test VMs for '
+                    'ovs_interface_rx/tx_packets/bytes validation.'),
+    cfg.IntOpt('network_exporter_traffic_packet_tolerance_pct',
+               default=15,
+               help='Allowed shortfall (percent) versus '
+                    'network_exporter_traffic_ping_count when comparing '
+                    'OVS counter deltas.'),
     cfg.IntOpt('network_exporter_traffic_min_bytes_per_packet',
                default=64,
                help='Minimum expected byte delta per counted packet when '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -146,6 +146,18 @@ NfvPluginOptions = [
                help='When probes were transmitted, scale the counter '
                     'expectation to this percent of xmit count (metric-storage '
                     'typically reflects well under half of routed ICMP).'),
+    cfg.StrOpt('network_exporter_datapath_name',
+               default='ovs-system',
+               help='OVS kernel datapath name for ovs_datapath_* metrics and '
+                    'ovs-dpctl ground-truth checks.'),
+    cfg.IntOpt('network_exporter_datapath_min_flow_increase',
+               default=1,
+               help='Minimum ovs_datapath_flows_total increase after VM boot '
+                    'and dataplane traffic.'),
+    cfg.IntOpt('network_exporter_datapath_lookup_min_hits',
+               default=1000,
+               help='Minimum ovs_datapath_lookup_hits_total increase after '
+                    'sustained VM ICMP traffic.'),
     cfg.IntOpt('network_exporter_error_udp_flood_packets',
                default=50000,
                help='UDP datagrams sent at high rate to a peer dataplane IP '

--- a/nfv_tempest_plugin/config.py
+++ b/nfv_tempest_plugin/config.py
@@ -163,6 +163,15 @@ NfvPluginOptions = [
                default=1000,
                help='Minimum ovs_datapath_lookup_hits_total increase after '
                     'sustained VM ICMP traffic.'),
+    cfg.IntOpt('network_exporter_pmd_min_iterations',
+               default=1000,
+               help='Minimum summed ovs_pmd_total/busy_iterations increase '
+                    'after VM ICMP traffic on DPDK computes.'),
+    cfg.IntOpt('network_exporter_pmd_min_packets',
+               default=0,
+               help='Minimum summed ovs_pmd_rx/tx_packets increase after VM '
+                    'traffic. 0 scales from network_exporter_traffic_ping_count '
+                    'and packet tolerance.'),
     cfg.IntOpt('network_exporter_error_udp_flood_packets',
                default=50000,
                help='UDP datagrams sent at high rate to a peer dataplane IP '

--- a/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
+++ b/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
@@ -498,6 +498,12 @@ class BareMetalManager(api_version_utils.BaseMicroversionTest,
             for net in nets:
                 if not net['router:external'] \
                         and 'HA network tenant' not in net['name']:
+                    if not net.get('subnets'):
+                        LOG.warning(
+                            'Skipping network %s (%s) with no subnets when '
+                            'adding router interfaces',
+                            net.get('name'), net.get('id'))
+                        continue
                     subnets.append(net['subnets'][0])
         else:
             subnets.append(mgmt_net['subnet-id'])

--- a/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
+++ b/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
@@ -481,19 +481,27 @@ class BareMetalManager(api_version_utils.BaseMicroversionTest,
         if mgmt_network is not None:
             self.mgmt_network = mgmt_network
 
-    def _add_subnet_to_router(self, mgmt_subnet_only=False):
+    def _add_subnet_to_router(self, mgmt_subnet_only=False,
+                              test_networks_only=False):
         """Add subnets of existing networks to the router
 
         The subnets attached to the router will get the ability for the
         instances to get dhcp allocations on the instance interfaces
 
         :param mgmt_subnet_only: Attach only mgmt network subnet to router
+        :param test_networks_only: Attach only subnets from test_network_dict
         """
         mgmt_net_name = self.mgmt_network
         mgmt_net = self.test_network_dict[mgmt_net_name]
 
         subnets = []
-        if not mgmt_subnet_only:
+        if mgmt_subnet_only:
+            subnets.append(mgmt_net['subnet-id'])
+        elif test_networks_only:
+            for net_param in self.test_network_dict.values():
+                if net_param.get('subnet-id'):
+                    subnets.append(net_param['subnet-id'])
+        else:
             nets = self.os_admin.networks_client.list_networks()['networks']
             for net in nets:
                 if not net['router:external'] \
@@ -505,8 +513,6 @@ class BareMetalManager(api_version_utils.BaseMicroversionTest,
                             net.get('name'), net.get('id'))
                         continue
                     subnets.append(net['subnets'][0])
-        else:
-            subnets.append(mgmt_net['subnet-id'])
         seen_routers = self.os_admin.routers_client.list_routers()['routers']
         self.assertGreater(len(seen_routers), 0,
                            "Test require at least admin router. please check")
@@ -1036,10 +1042,16 @@ class BareMetalManager(api_version_utils.BaseMicroversionTest,
             router_exist = self.test_setup_dict[test]['router']
         if router_exist:
             mgmt_subnet_only = False
+            test_networks_only = False
             if kwargs.get('mgmt_subnet_only'):
                 mgmt_subnet_only = True
                 kwargs.pop('mgmt_subnet_only')
-            self._add_subnet_to_router(mgmt_subnet_only)
+            if kwargs.get('test_networks_only'):
+                test_networks_only = True
+                kwargs.pop('test_networks_only')
+            self._add_subnet_to_router(
+                mgmt_subnet_only=mgmt_subnet_only,
+                test_networks_only=test_networks_only)
         # Prepare cloudinit
         packages = None
         if 'package-names' in self.test_setup_dict[test].keys():

--- a/nfv_tempest_plugin/tests/scenario/manager_utils.py
+++ b/nfv_tempest_plugin/tests/scenario/manager_utils.py
@@ -758,6 +758,15 @@ class ManagerMixin(object):
 
         return statistics
 
+    def _ovs_interface_stat_int(self, stats, key):
+        """Return one OVS Interface statistics counter (missing keys mean zero)."""
+        if not stats:
+            return 0
+        value = stats.get(key, 0)
+        if value is None:
+            return 0
+        return int(value)
+
     def get_ovs_multicast_groups(self, switch, multicast_ip=None,
                                  hypervisor=None):
         """This method get ovs multicast groups

--- a/nfv_tempest_plugin/tests/scenario/manager_utils.py
+++ b/nfv_tempest_plugin/tests/scenario/manager_utils.py
@@ -767,6 +767,21 @@ class ManagerMixin(object):
             return 0
         return int(value)
 
+    def _ovs_interface_error_exporter_value(self, stats, stat_key):
+        """Return OVS error counter as openstack-network-exporter iface does."""
+        if stat_key == 'rx_dropped':
+            missed = self._ovs_interface_stat_int(stats, 'rx_missed_errors')
+            if missed > 0:
+                return missed
+            return self._ovs_interface_stat_int(stats, 'rx_dropped')
+        if stat_key == 'tx_errors':
+            failures = self._ovs_interface_stat_int(
+                stats, 'ovs_tx_failure_drops')
+            if failures > 0:
+                return failures
+            return self._ovs_interface_stat_int(stats, 'tx_errors')
+        return self._ovs_interface_stat_int(stats, stat_key)
+
     def get_ovs_multicast_groups(self, switch, multicast_ip=None,
                                  hypervisor=None):
         """This method get ovs multicast groups

--- a/nfv_tempest_plugin/tests/scenario/manager_utils.py
+++ b/nfv_tempest_plugin/tests/scenario/manager_utils.py
@@ -713,6 +713,35 @@ class ManagerMixin(object):
                         .split('.')[0]}
         return servers, key_pair
 
+    @staticmethod
+    def _parse_ovs_statistics_map(raw):
+        """Parse ovs-vsctl statistics map output into a string->int dict."""
+        text = (raw or '').strip()
+        if not text or text in ('{}', '[]'):
+            return {}
+        if text.startswith('{') and text.endswith('}'):
+            text = text[1:-1].strip()
+        if not text:
+            return {}
+        stats = {}
+        for item in text.split(','):
+            item = item.strip()
+            if '=' not in item:
+                continue
+            key, _, value = item.partition('=')
+            key = key.strip().strip('"')
+            value = value.strip().strip('"')
+            if not key:
+                continue
+            try:
+                stats[key] = int(value)
+            except (TypeError, ValueError):
+                try:
+                    stats[key] = int(float(value))
+                except (TypeError, ValueError):
+                    continue
+        return stats
+
     def get_ovs_interface_statistics(self, interfaces, previous_stats=None,
                                      hypervisor=None):
         """This method get ovs interface statistics
@@ -740,12 +769,14 @@ class ManagerMixin(object):
         for interface in interfaces:
             command = 'sudo ovs-vsctl get Interface {} ' \
                       'statistics'.format(interface)
-            statistics[interface] = \
-                yaml.safe_load(
-                    shell_utils.run_command_over_ssh(
-                        hypervisor_ip, command).replace(
-                        '"', '').replace(
-                        '{', '{"').replace(', ', ', "').replace('=', '":'))
+            raw = shell_utils.run_command_over_ssh(
+                hypervisor_ip, command)
+            statistics[interface] = self._parse_ovs_statistics_map(raw)
+            if not statistics[interface] and (raw or '').strip() not in (
+                    '', '{}', '[]'):
+                LOG.warning(
+                    'Could not parse OVS statistics for %s on %s: %r',
+                    interface, hypervisor_ip, raw[:500])
             if previous_stats is not None and \
                interface in previous_stats.keys():
                 for stat in statistics[interface].keys():

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -49,8 +49,60 @@ OVS_INTERFACE_LINK_STATE_METRIC = 'ovs_interface_link_state'
 OVS_INTERFACE_MTU_BYTES_METRIC = 'ovs_interface_mtu_bytes'
 OVS_INTERFACE_LINK_SPEED_BPS_METRIC = 'ovs_interface_link_speed_bps'
 OVS_INTERFACE_LINK_RESETS_METRIC = 'ovs_interface_link_resets'
+OVS_INTERFACE_RX_PACKETS_METRIC = 'ovs_interface_rx_packets'
+OVS_INTERFACE_TX_PACKETS_METRIC = 'ovs_interface_tx_packets'
+OVS_INTERFACE_RX_BYTES_METRIC = 'ovs_interface_rx_bytes'
+OVS_INTERFACE_TX_BYTES_METRIC = 'ovs_interface_tx_bytes'
+OVS_INTERFACE_STAT_TO_METRIC = {
+    'rx_packets': OVS_INTERFACE_RX_PACKETS_METRIC,
+    'tx_packets': OVS_INTERFACE_TX_PACKETS_METRIC,
+    'rx_bytes': OVS_INTERFACE_RX_BYTES_METRIC,
+    'tx_bytes': OVS_INTERFACE_TX_BYTES_METRIC,
+}
+NET_VF_INFO_METRIC = 'net_vf_info'
+NET_VF_RECEIVE_PACKETS_METRIC = 'net_vf_receive_packets_total'
+NET_VF_TRANSMIT_PACKETS_METRIC = 'net_vf_transmit_packets_total'
+NET_VF_RECEIVE_BYTES_METRIC = 'net_vf_receive_bytes_total'
+NET_VF_TRANSMIT_BYTES_METRIC = 'net_vf_transmit_bytes_total'
+NET_VF_RECEIVE_DROPPED_METRIC = 'net_vf_receive_dropped_total'
+NET_VF_TRANSMIT_DROPPED_METRIC = 'net_vf_transmit_dropped_total'
+NET_VF_BROADCAST_PACKETS_METRIC = 'net_vf_broadcast_packets_total'
+NET_VF_MULTICAST_PACKETS_METRIC = 'net_vf_multicast_packets_total'
+NET_VF_COUNTER_METRICS = (
+    NET_VF_RECEIVE_PACKETS_METRIC,
+    NET_VF_TRANSMIT_PACKETS_METRIC,
+    NET_VF_RECEIVE_BYTES_METRIC,
+    NET_VF_TRANSMIT_BYTES_METRIC,
+    NET_VF_BROADCAST_PACKETS_METRIC,
+    NET_VF_MULTICAST_PACKETS_METRIC,
+)
+NET_VF_ALL_METRICS = (
+    NET_VF_INFO_METRIC,
+    NET_VF_RECEIVE_PACKETS_METRIC,
+    NET_VF_TRANSMIT_PACKETS_METRIC,
+    NET_VF_RECEIVE_BYTES_METRIC,
+    NET_VF_TRANSMIT_BYTES_METRIC,
+    NET_VF_RECEIVE_DROPPED_METRIC,
+    NET_VF_TRANSMIT_DROPPED_METRIC,
+    NET_VF_BROADCAST_PACKETS_METRIC,
+    NET_VF_MULTICAST_PACKETS_METRIC,
+)
+# Host sysfs under .../sriov/vfN/stats/ (same source as net_vf exporter).
+NET_VF_METRIC_TO_SYSFS_STAT = {
+    NET_VF_RECEIVE_PACKETS_METRIC: 'rx_packets',
+    NET_VF_TRANSMIT_PACKETS_METRIC: 'tx_packets',
+    NET_VF_RECEIVE_BYTES_METRIC: 'rx_bytes',
+    NET_VF_TRANSMIT_BYTES_METRIC: 'tx_bytes',
+    NET_VF_RECEIVE_DROPPED_METRIC: 'rx_dropped',
+    NET_VF_TRANSMIT_DROPPED_METRIC: 'tx_dropped',
+}
 # OVN/K8s service metrics (northd, controller, etc.), not compute :9105
 OVN_K8S_METRICS_PORT = ':1981'
+PROM_METRIC_LINE_RE = re.compile(
+    r'^(?P<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)'
+    r'\{(?P<labels>[^}]*)\}\s+'
+    r'(?P<value>-?\d+(?:\.\d+)?)$')
+PROM_LABEL_RE = re.compile(r'(\w+)="([^"]*)"')
 # openstack-network-exporter: 0=standby, 1=active, 2=paused
 OVN_NORTHD_STATUS_VALUES = (0, 1, 2)
 OVN_NORTHD_STATUS_ACTIVE = 1
@@ -69,6 +121,9 @@ LEGACY_STATE_TEST_INTERFACES = (
     'tempest-ovs-state-test',
     'tempest-ovs-state-test-host',
 )
+PING_FAST_INTERVAL_SEC = 0.001
+PING_SLOW_INTERVAL_SEC = 0.2
+PING_MAX_WALL_SECONDS = 120
 
 
 class NetworkExporterMetricsBase(base_test.BaseTest):
@@ -142,6 +197,47 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             return data.get('data', {}).get('result', []), ''
         return None, '; '.join(errors) or 'Prometheus query failed'
 
+    def _fetch_metric_storage_promql_results(self, metric_name):
+        """Query metric-storage Prometheus for instant vector samples."""
+        query = 'last_over_time(%s[5m])' % metric_name
+        results, error = self._query_prometheus(query)
+        if results:
+            return results, ''
+        return [], error or 'metric-storage query failed'
+
+    def _sample_matches_hypervisor(self, labels, hypervisor_ip):
+        """True when a metric-storage sample belongs to hypervisor_ip."""
+        row_text = ' '.join(
+            labels.get(key, '') for key in ('instance', 'fqdn', 'hostname'))
+        for ident in self._hypervisor_identifiers(hypervisor_ip):
+            ident_short = ident.split('.')[0]
+            if ident in row_text or ident_short in row_text:
+                return True
+        return False
+
+    def _metric_storage_samples(self, metric_name, hypervisor_ip=None,
+                                required_labels=None):
+        """Return metric-storage samples filtered by hypervisor and labels."""
+        results, error = self._fetch_metric_storage_promql_results(metric_name)
+        samples = []
+        for result in results:
+            labels = result.get('metric', {})
+            value = result.get('value', [None, None])[1]
+            if value is None:
+                continue
+            if (hypervisor_ip and
+                    not self._sample_matches_hypervisor(labels, hypervisor_ip)):
+                continue
+            if required_labels and any(
+                    labels.get(key) != val
+                    for key, val in required_labels.items()):
+                continue
+            samples.append({
+                'labels': labels,
+                'value': int(float(value)),
+            })
+        return samples, error
+
     def _metric_show(self, metric_name):
         """Query metric-storage Prometheus for metric values."""
         query = 'last_over_time(%s[5m])' % metric_name
@@ -157,6 +253,105 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         except Exception as exc:
             LOG.warning("Prometheus query error: %s", exc)
             return '', str(exc), 1
+
+    def _scrape_compute_metrics_text(self, hypervisor_ip):
+        """Return openstack-network-exporter Prometheus text from a compute node."""
+        cmd_https = "curl -sk https://127.0.0.1:9105/metrics 2>/dev/null"
+        metrics_output = self._ssh_run_on_hypervisor(hypervisor_ip, cmd_https)
+        if metrics_output.strip():
+            return metrics_output
+        cmd_http = "curl -s http://127.0.0.1:9105/metrics 2>/dev/null"
+        return self._ssh_run_on_hypervisor(hypervisor_ip, cmd_http)
+
+    def _guest_has_passwordless_sudo(self, ssh_client):
+        """Return True when the guest accepts ``sudo -n`` without prompting."""
+        try:
+            ssh_client.exec_command('sudo -n true')
+            return True
+        except Exception:
+            return False
+
+    def _send_ping_packets(self, ssh_client, dest_ip, count, min_packets):
+        """Send ICMP echo requests between guests for traffic counter tests.
+
+        Unprivileged ``ping -i 0.001`` is rejected on RHEL/iputils (200ms floor).
+        When passwordless sudo is unavailable, fall back to ``-i 0.2`` bounded by
+        ``PING_MAX_WALL_SECONDS`` so SSH exec does not time out.
+        """
+        errors = []
+        if self._guest_has_passwordless_sudo(ssh_client):
+            for template in (
+                    'timeout %d sudo -n ping -c %d -i %g -W 2 %s',
+                    'ping -c %d -i %g -W 2 %s'):
+                if 'sudo' in template:
+                    wall = max(30, int(count * PING_FAST_INTERVAL_SEC) + 15)
+                    cmd = template % (
+                        wall, count, PING_FAST_INTERVAL_SEC, dest_ip)
+                else:
+                    cmd = template % (
+                        count, PING_FAST_INTERVAL_SEC, dest_ip)
+                LOG.warning('Sending dataplane ping: %s', cmd)
+                try:
+                    output = ssh_client.exec_command(cmd)
+                except Exception as exc:
+                    errors.append('%s -> %s' % (cmd, exc))
+                    continue
+                if '100% packet loss' in (output or ''):
+                    errors.append('%s -> 100%% packet loss' % cmd)
+                    continue
+                return output
+
+        slow_count = min(
+            count,
+            int(PING_MAX_WALL_SECONDS / PING_SLOW_INTERVAL_SEC))
+        if slow_count < min_packets:
+            self.fail(
+                'Cannot send %d ICMP replies (need >=%d) within %ds without '
+                'passwordless sudo on the guest. Lower the traffic ping count '
+                'to <= %d (at %.1fs interval) or grant passwordless sudo for '
+                'ping.' % (
+                    count, min_packets, PING_MAX_WALL_SECONDS, slow_count,
+                    PING_SLOW_INTERVAL_SEC))
+        wall = int(slow_count * PING_SLOW_INTERVAL_SEC) + 15
+        cmd = 'timeout %d ping -c %d -i %g -W 2 %s' % (
+            wall, slow_count, PING_SLOW_INTERVAL_SEC, dest_ip)
+        LOG.warning('Sending dataplane ping (slow path): %s', cmd)
+        try:
+            output = ssh_client.exec_command(cmd)
+        except Exception as exc:
+            errors.append('%s -> %s' % (cmd, exc))
+        else:
+            if '100% packet loss' not in (output or ''):
+                return output
+            errors.append('%s -> 100%% packet loss' % cmd)
+        if errors:
+            detail = '; '.join(errors)
+        else:
+            detail = 'slow ping path failed'
+        self.fail('Ping to %s failed: %s' % (dest_ip, detail))
+
+    def _assert_metric_on_compute_scrape(self, metric_name):
+        """Verify metric_name is exported on at least one compute :9105 scrape."""
+        hypervisors = self._get_hypervisor_ip_from_undercloud()
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisor IPs available for :9105 scrape')
+        found_on = []
+        for hypervisor_ip in hypervisors:
+            for line in self._scrape_compute_metrics_text(
+                    hypervisor_ip).splitlines():
+                stripped = line.strip()
+                if stripped.startswith(metric_name + '{') or stripped.startswith(
+                        metric_name + ' '):
+                    found_on.append(hypervisor_ip)
+                    break
+        self.assertNotEmpty(
+            found_on,
+            "Metric '%s' not found on :9105 scrape from hypervisors %s" % (
+                metric_name, hypervisors))
+        LOG.warning(
+            "Metric '%s' found on compute :9105 scrape from %s",
+            metric_name, found_on)
 
     def _assert_metric_reported(self, metric_name, output_markers=None):
         """Wait until metric_name is present in metric-storage Prometheus."""
@@ -780,3 +975,22 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             self._delete_test_interface, hypervisor_ip, bridge, interface)
         self._ensure_port_up(hypervisor_ip, interface)
         return hypervisor_ip, interface
+
+    def _parse_prom_samples(self, metrics_output, metric_name,
+                            required_labels=None):
+        """Parse Prometheus exposition text into label/value samples."""
+        samples = []
+        for line in (metrics_output or '').splitlines():
+            match = PROM_METRIC_LINE_RE.match(line.strip())
+            if not match or match.group('metric') != metric_name:
+                continue
+            labels = dict(PROM_LABEL_RE.findall(match.group('labels')))
+            if required_labels and any(
+                    labels.get(key) != value
+                    for key, value in required_labels.items()):
+                continue
+            samples.append({
+                'labels': labels,
+                'value': int(float(match.group('value'))),
+            })
+        return samples

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -488,10 +488,11 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                    max(30, int(count * PING_SLOW_INTERVAL_SEC) + 15))
         capped = min(count, int(wall / PING_SLOW_INTERVAL_SEC))
         if capped < min_packets:
-            self.fail(
-                'Bound ping count %d below minimum %d without passwordless '
-                'sudo (cap %d at %gs interval)' % (
-                    capped, min_packets, capped, PING_SLOW_INTERVAL_SEC))
+            LOG.warning(
+                'Bound ping capped at %d without passwordless sudo '
+                '(requested min %d); using capped count at %gs interval',
+                capped, min_packets, PING_SLOW_INTERVAL_SEC)
+            min_packets = capped
         cmd = 'timeout %d ping -c %d -I %s -i %g -W 2 %s' % (
             wall, capped, bind_ip, PING_SLOW_INTERVAL_SEC, dest_ip)
         LOG.warning('Sending bound ping (slow path): %s', cmd)

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -147,8 +147,6 @@ PING_FAST_FLOOD_MIN_WALL_SECONDS = 90
 # Tempest SSH exec often returns after ~30s; batch routed floods to stay under it.
 PING_FAST_BATCH_PACKETS = 600
 PING_FAST_BATCH_MAX_WALL_SECONDS = 25
-GUEST_PING_FLOOD_MARKER = '/tmp/tpst-router-ping.done'
-GUEST_PING_FLOOD_LOG = '/tmp/tpst-router-ping.log'
 
 
 class NetworkExporterMetricsBase(base_test.BaseTest):
@@ -479,62 +477,6 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         if sudo:
             cmd = '%s %s' % (sudo, cmd)
         return ssh_client.exec_command(cmd)
-
-    def _send_bound_ping_flood_on_guest(self, ssh_client, bind_ip, dest_ip,
-                                        count, min_packets):
-        """Run a bound ICMP flood on the guest outside Tempest SSH exec limits."""
-        batch = PING_FAST_BATCH_PACKETS
-        marker = GUEST_PING_FLOOD_MARKER
-        script = (
-            'import subprocess\n'
-            'bind = %r\n'
-            'dest = %r\n'
-            'total = %d\n'
-            'batch = %d\n'
-            'interval = %g\n'
-            'marker = %r\n'
-            'sent = 0\n'
-            'while sent < total:\n'
-            '    n = min(batch, total - sent)\n'
-            '    cmd = ["ping", "-c", str(n), "-I", bind, "-i", str(interval),\n'
-            '           "-W", "2", dest]\n'
-            '    proc = subprocess.run(cmd, capture_output=True, text=True)\n'
-            '    out = (proc.stdout or "") + (proc.stderr or "")\n'
-            '    if proc.returncode != 0 or "100%% packet loss" in out:\n'
-            '        break\n'
-            '    sent += n\n'
-            'open(marker, "w").write(str(sent))\n'
-            % (bind_ip, dest_ip, count, batch, PING_FAST_INTERVAL_SEC,
-               marker))
-        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
-        sudo = self._guest_sudo_prefix(ssh_client)
-        prefix = '%s ' % sudo if sudo else ''
-        start_cmd = (
-            "rm -f %s; nohup sh -c '%secho %s | base64 -d | python3' "
-            ">>%s 2>&1 &" % (marker, prefix, encoded, GUEST_PING_FLOOD_LOG))
-        LOG.warning(
-            'Starting guest background bound ping flood %s -> %s count %d',
-            bind_ip, dest_ip, count)
-        ssh_client.exec_command(start_cmd)
-        wall = max(180, int(count * PING_FAST_FLOOD_PER_PACKET_SEC) + 120)
-        deadline = time.time() + wall
-        while time.time() < deadline:
-            out = (ssh_client.exec_command(
-                'cat %s 2>/dev/null || true' % marker) or '').strip()
-            if out.isdigit():
-                sent = int(out)
-                LOG.warning(
-                    'Guest bound ping flood finished: %d/%d transmitted',
-                    sent, count)
-                if sent < min(min_packets, count):
-                    self.fail(
-                        'Guest bound ping flood sent %d packets (need >= %d)' %
-                        (sent, min_packets))
-                return sent
-            time.sleep(5)
-        self.fail(
-            'Timed out waiting for guest bound ping flood marker %s '
-            '(limit %ds)' % (marker, wall))
 
     def _send_ping_packets_bound(self, ssh_client, bind_ip, dest_ip, count,
                                  min_packets):

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -81,6 +81,27 @@ OVS_DATAPATH_METRIC_TO_DPCTL_KEY = {
     OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC: 'missed',
     OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC: 'lost',
 }
+OVS_PMD_TOTAL_ITERATIONS_METRIC = 'ovs_pmd_total_iterations'
+OVS_PMD_IDLE_ITERATIONS_METRIC = 'ovs_pmd_idle_iterations'
+OVS_PMD_BUSY_ITERATIONS_METRIC = 'ovs_pmd_busy_iterations'
+OVS_PMD_RX_PACKETS_METRIC = 'ovs_pmd_rx_packets'
+OVS_PMD_TX_PACKETS_METRIC = 'ovs_pmd_tx_packets'
+OVS_PMD_ITERATION_METRICS = (
+    OVS_PMD_TOTAL_ITERATIONS_METRIC,
+    OVS_PMD_IDLE_ITERATIONS_METRIC,
+    OVS_PMD_BUSY_ITERATIONS_METRIC,
+)
+OVS_PMD_PACKET_METRICS = (
+    OVS_PMD_RX_PACKETS_METRIC,
+    OVS_PMD_TX_PACKETS_METRIC,
+)
+OVS_PMD_METRIC_TO_PERF_STAT = {
+    OVS_PMD_TOTAL_ITERATIONS_METRIC: 'Iterations',
+    OVS_PMD_IDLE_ITERATIONS_METRIC: '- idle iterations',
+    OVS_PMD_BUSY_ITERATIONS_METRIC: '- busy iterations',
+    OVS_PMD_RX_PACKETS_METRIC: 'Rx packets',
+    OVS_PMD_TX_PACKETS_METRIC: 'Tx packets',
+}
 NET_VF_INFO_METRIC = 'net_vf_info'
 NET_VF_RECEIVE_PACKETS_METRIC = 'net_vf_receive_packets_total'
 NET_VF_TRANSMIT_PACKETS_METRIC = 'net_vf_transmit_packets_total'
@@ -148,6 +169,12 @@ DPCTL_SHOW_COMMANDS = (
     'ovs-appctl dpctl/show 2>/dev/null',
     'sudo ovs-dpctl show -s 2>/dev/null',
     'sudo ovs-dpctl show 2>/dev/null',
+)
+PMD_THREAD_RE = re.compile(r'^pmd thread numa_id (\d+) core_id (\d+):$')
+PMD_PERF_STAT_RE = re.compile(r'^\s*([^:]+):\s+(\d+)\s*(.*)$')
+PMD_PERF_SHOW_COMMANDS = (
+    'sudo ovs-appctl dpif-netdev/pmd-perf-show 2>/dev/null',
+    'ovs-appctl dpif-netdev/pmd-perf-show 2>/dev/null',
 )
 METRIC_ROW_VALUE_RE = re.compile(r'(\d+)\s*\|?\s*$')
 COMPUTE_METRICS_HOST_RE = re.compile(
@@ -1110,6 +1137,158 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         self.fail(
             'Timed out waiting for datapath %s on %s to match dpctl/show' % (
                 metric_name, hypervisor_ip))
+
+    def _pmd_perf_show_output(self, hypervisor_ip):
+        """Fetch dpif-netdev/pmd-perf-show (same source as network-exporter)."""
+        last_output = ''
+        for cmd in PMD_PERF_SHOW_COMMANDS:
+            output = self._ssh_run_on_hypervisor(
+                hypervisor_ip, cmd, check_rc=False)
+            if output and output.strip():
+                return output
+            last_output = output or last_output
+        self.fail(
+            'Could not get pmd-perf-show on %s (last output: %r)' % (
+                hypervisor_ip, (last_output or '')[:500]))
+
+    def _ovs_pmd_perf_stats_map(self, hypervisor_ip):
+        """Map (numa, cpu) -> pmd-perf-show stat name -> value."""
+        output = self._pmd_perf_show_output(hypervisor_ip)
+        result = {}
+        numa = cpu = None
+        for line in output.splitlines():
+            thread = PMD_THREAD_RE.match(line)
+            if thread:
+                numa, cpu = thread.group(1), thread.group(2)
+                result[(numa, cpu)] = {}
+                continue
+            if numa is None:
+                continue
+            stat = PMD_PERF_STAT_RE.match(line)
+            if stat:
+                result[(numa, cpu)][stat.group(1).strip()] = int(stat.group(2))
+        return result
+
+    def _pmd_thread_key(self, labels):
+        return labels.get('numa'), labels.get('cpu')
+
+    def _pmd_live_samples(self, hypervisor_ip, metric_name):
+        """Return all ovs_pmd_* samples from live :9105 on one hypervisor."""
+        return self._parse_prom_samples(
+            self._scrape_compute_metrics_text(hypervisor_ip), metric_name)
+
+    def _pmd_live_total(self, hypervisor_ip, metric_name):
+        """Sum ovs_pmd_* across all PMD threads on one hypervisor."""
+        return sum(
+            sample['value']
+            for sample in self._pmd_live_samples(hypervisor_ip, metric_name))
+
+    def _pmd_perf_total(self, hypervisor_ip, metric_name):
+        """Sum one pmd-perf-show stat across all PMD threads."""
+        stat_name = OVS_PMD_METRIC_TO_PERF_STAT.get(metric_name)
+        if not stat_name:
+            return 0
+        return sum(
+            stats.get(stat_name, 0)
+            for stats in self._ovs_pmd_perf_stats_map(hypervisor_ip).values())
+
+    def _hypervisors_with_pmd_perf(self, hypervisors):
+        """Return hypervisors that export pmd-perf-show stats."""
+        found = []
+        for hypervisor_ip in hypervisors:
+            try:
+                if self._ovs_pmd_perf_stats_map(hypervisor_ip):
+                    found.append(hypervisor_ip)
+            except Exception as exc:
+                LOG.warning(
+                    'No pmd-perf-show on %s: %s', hypervisor_ip, exc)
+        return found
+
+    def _assert_pmd_matches_perf_show(self, hypervisor_ip, metric_name):
+        """Assert live :9105 ovs_pmd_* matches pmd-perf-show on hypervisor."""
+        stat_name = OVS_PMD_METRIC_TO_PERF_STAT.get(metric_name)
+        self.assertIsNotNone(
+            stat_name, 'No pmd-perf-show mapping for metric %s' % metric_name)
+        last_exc = None
+        for attempt in range(METRIC_RETRY_ATTEMPTS):
+            perf_map = self._ovs_pmd_perf_stats_map(hypervisor_ip)
+            live_by_key = {
+                self._pmd_thread_key(sample['labels']): sample['value']
+                for sample in self._pmd_live_samples(hypervisor_ip, metric_name)
+            }
+            try:
+                self.assertNotEmpty(
+                    perf_map,
+                    'pmd-perf-show empty on %s' % hypervisor_ip)
+                self.assertNotEmpty(
+                    live_by_key,
+                    '%s missing on live :9105 on %s' % (
+                        metric_name, hypervisor_ip))
+                matched = False
+                for thread_key, stats in perf_map.items():
+                    if stat_name not in stats:
+                        continue
+                    expected = stats[stat_name]
+                    reported = live_by_key.get(thread_key)
+                    if reported is None:
+                        continue
+                    self.assertEqual(
+                        expected, reported,
+                        '%s on %s numa=%s cpu=%s: perf-show %s=%s live=%s' % (
+                            metric_name, hypervisor_ip, thread_key[0],
+                            thread_key[1], stat_name, expected, reported))
+                    matched = True
+                    LOG.warning(
+                        'PMD %s aligned with pmd-perf-show on %s numa=%s '
+                        'cpu=%s (attempt %s): %s',
+                        metric_name, hypervisor_ip, thread_key[0],
+                        thread_key[1], attempt + 1, expected)
+                    return
+                self.fail(
+                    '%s on %s: no pmd-perf-show thread matched live :9105 '
+                    '(perf threads %s, live threads %s)' % (
+                        metric_name, hypervisor_ip,
+                        list(perf_map.keys()), list(live_by_key.keys())))
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for PMD %s on %s: %s',
+                    attempt + 1, METRIC_RETRY_ATTEMPTS, metric_name,
+                    hypervisor_ip, exc)
+            if attempt < METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(METRIC_RETRY_INTERVAL)
+        if last_exc is not None:
+            raise last_exc
+        self.fail(
+            'Timed out waiting for PMD %s on %s to match pmd-perf-show' % (
+                metric_name, hypervisor_ip))
+
+    def _assert_pmd_metric_reported(self, metric_name):
+        """Assert ovs_pmd_* via metric show, :9105, and pmd-perf-show."""
+        self._assert_ovs_interface_metric_reported(metric_name)
+        hypervisors = self._get_ssh_hypervisors('')
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisors available for PMD metric %s' % metric_name)
+        pmd_hypervisors = self._hypervisors_with_pmd_perf(hypervisors)
+        self.assertNotEmpty(
+            pmd_hypervisors,
+            'No DPDK pmd-perf-show output on hypervisors %s for %s' % (
+                hypervisors, metric_name))
+        last_exc = None
+        for hypervisor_ip in pmd_hypervisors:
+            try:
+                self._assert_pmd_matches_perf_show(
+                    hypervisor_ip, metric_name)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'PMD perf-show check failed on %s for %s: %s',
+                    hypervisor_ip, metric_name, exc)
+        self.fail(
+            'PMD metric %s did not match pmd-perf-show on any hypervisor %s; '
+            'last error: %s' % (metric_name, pmd_hypervisors, last_exc))
 
     def _assert_metric_on_compute_scrape(self, metric_name):
         """Verify metric_name is exported on at least one compute :9105 scrape."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -95,6 +95,12 @@ OVS_PMD_PACKET_METRICS = (
     OVS_PMD_RX_PACKETS_METRIC,
     OVS_PMD_TX_PACKETS_METRIC,
 )
+OVS_PMD_CPU_OVERHEAD_METRIC = 'ovs_pmd_cpu_overhead'
+OVS_PMD_RXQ_USAGE_METRIC = 'ovs_pmd_rxq_usage'
+OVS_PMD_CPU_USAGE_METRICS = (
+    OVS_PMD_CPU_OVERHEAD_METRIC,
+    OVS_PMD_RXQ_USAGE_METRIC,
+)
 OVS_PMD_METRIC_TO_PERF_STAT = {
     OVS_PMD_TOTAL_ITERATIONS_METRIC: 'Iterations',
     OVS_PMD_IDLE_ITERATIONS_METRIC: '- idle iterations',
@@ -176,6 +182,14 @@ PMD_PERF_SHOW_COMMANDS = (
     'sudo ovs-appctl dpif-netdev/pmd-perf-show 2>/dev/null',
     'ovs-appctl dpif-netdev/pmd-perf-show 2>/dev/null',
 )
+PMD_RXQ_SHOW_COMMANDS = (
+    'sudo ovs-appctl dpif-netdev/pmd-rxq-show 2>/dev/null',
+    'ovs-appctl dpif-netdev/pmd-rxq-show 2>/dev/null',
+)
+PMD_RXQ_OVERHEAD_RE = re.compile(r'^\s*overhead\s*:\s*([\d.]+)\s*%$')
+PMD_RXQ_USAGE_RE = re.compile(
+    r'^\s*port:\s*(\S+)\s+queue-id:\s*(\d+)\s+\((enabled|disabled)\)\s+'
+    r'pmd usage:\s*([\d.]+)\s*%$')
 METRIC_ROW_VALUE_RE = re.compile(r'(\d+)\s*\|?\s*$')
 COMPUTE_METRICS_HOST_RE = re.compile(
     r'(\d+\.\d+\.\d+\.\d+)' + re.escape(NETWORK_EXPORTER_INSTANCE_PORT))
@@ -1318,6 +1332,201 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         self.fail(
             'PMD metric %s did not match pmd-perf-show on any hypervisor %s; '
             'last error: %s' % (metric_name, pmd_hypervisors, last_exc))
+
+    def _pmd_rxq_show_output(self, hypervisor_ip):
+        """Fetch dpif-netdev/pmd-rxq-show (same source as network-exporter)."""
+        last_output = ''
+        for cmd in PMD_RXQ_SHOW_COMMANDS:
+            output = self._ssh_run_on_hypervisor(
+                hypervisor_ip, cmd, check_rc=False)
+            if output and output.strip():
+                return output
+            last_output = output or last_output
+        self.fail(
+            'Could not get pmd-rxq-show on %s (last output: %r)' % (
+                hypervisor_ip, (last_output or '')[:500]))
+
+    def _ovs_pmd_rxq_stats(self, hypervisor_ip, output=None):
+        """Parse pmd-rxq-show into overhead and per-Rxq usage percentages."""
+        if output is None:
+            output = self._pmd_rxq_show_output(hypervisor_ip)
+        overhead = {}
+        rxq_usage = {}
+        numa = cpu = None
+        for line in output.splitlines():
+            thread = PMD_THREAD_RE.match(line)
+            if thread:
+                numa, cpu = thread.group(1), thread.group(2)
+                continue
+            if numa is None:
+                continue
+            oh = PMD_RXQ_OVERHEAD_RE.match(line)
+            if oh:
+                overhead[(numa, cpu)] = float(oh.group(1))
+                continue
+            rxq = PMD_RXQ_USAGE_RE.match(line)
+            if rxq:
+                interface = rxq.group(1)
+                queue_id = rxq.group(2)
+                usage = float(rxq.group(4))
+                rxq_usage[(numa, cpu, interface, queue_id)] = usage
+        return overhead, rxq_usage
+
+    def _pmd_rxq_and_live_output(self, hypervisor_ip):
+        """Fetch pmd-rxq-show and :9105 metrics in one SSH round-trip."""
+        cmd = (
+            'sudo ovs-appctl dpif-netdev/pmd-rxq-show 2>/dev/null; '
+            'curl -sk https://127.0.0.1:9105/metrics 2>/dev/null || '
+            'curl -s http://127.0.0.1:9105/metrics 2>/dev/null')
+        return self._ssh_run_on_hypervisor(hypervisor_ip, cmd, check_rc=False)
+
+    def _pmd_gauge_tolerance(self):
+        return CONF.nfv_plugin_options.network_exporter_pmd_gauge_tolerance
+
+    def _pmd_gauge_values_aligned(self, expected, reported):
+        return abs(expected - reported) <= self._pmd_gauge_tolerance()
+
+    def _pmd_rxq_label_key(self, labels):
+        return (
+            labels.get('numa'), labels.get('cpu'),
+            labels.get('interface'), labels.get('rxq'))
+
+    def _parse_prom_float_samples(self, metrics_output, metric_name,
+                                  required_labels=None):
+        """Parse Prometheus exposition text into float label/value samples."""
+        samples = []
+        for line in (metrics_output or '').splitlines():
+            match = PROM_METRIC_LINE_RE.match(line.strip())
+            if not match or match.group('metric') != metric_name:
+                continue
+            labels = dict(PROM_LABEL_RE.findall(match.group('labels')))
+            if required_labels and any(
+                    labels.get(key) != value
+                    for key, value in required_labels.items()):
+                continue
+            samples.append({
+                'labels': labels,
+                'value': float(match.group('value')),
+            })
+        return samples
+
+    def _hypervisors_with_pmd_rxq(self, hypervisors):
+        """Return hypervisors that export pmd-rxq-show stats."""
+        found = []
+        for hypervisor_ip in hypervisors:
+            try:
+                overhead, rxq_usage = self._ovs_pmd_rxq_stats(hypervisor_ip)
+                if overhead or rxq_usage:
+                    found.append(hypervisor_ip)
+            except Exception as exc:
+                LOG.warning(
+                    'No pmd-rxq-show on %s: %s', hypervisor_ip, exc)
+        return found
+
+    def _pmd_rxq_aligned_on_output(self, hypervisor_ip, metric_name, combined):
+        """Return True when live :9105 gauge matches pmd-rxq-show in output."""
+        overhead, rxq_usage = self._ovs_pmd_rxq_stats(
+            hypervisor_ip, output=combined)
+        live_samples = self._parse_prom_float_samples(combined, metric_name)
+        if not live_samples:
+            return False
+        if metric_name == OVS_PMD_CPU_OVERHEAD_METRIC:
+            if not overhead:
+                return False
+            live_by_key = {
+                self._pmd_thread_key(sample['labels']): sample['value']
+                for sample in live_samples}
+            for thread_key, expected in overhead.items():
+                reported = live_by_key.get(thread_key)
+                if reported is None:
+                    continue
+                if self._pmd_gauge_values_aligned(expected, reported):
+                    return True
+            return False
+        if metric_name == OVS_PMD_RXQ_USAGE_METRIC:
+            if not rxq_usage:
+                return False
+            live_by_key = {
+                self._pmd_rxq_label_key(sample['labels']): sample['value']
+                for sample in live_samples}
+            for rxq_key, expected in rxq_usage.items():
+                reported = live_by_key.get(rxq_key)
+                if reported is None:
+                    continue
+                if self._pmd_gauge_values_aligned(expected, reported):
+                    return True
+            return False
+        return False
+
+    def _assert_pmd_rxq_matches_show(self, hypervisor_ip, metric_name):
+        """Assert live :9105 ovs_pmd_* gauge matches pmd-rxq-show."""
+        last_exc = None
+        for attempt in range(METRIC_RETRY_ATTEMPTS):
+            combined = self._pmd_rxq_and_live_output(hypervisor_ip)
+            try:
+                if self._pmd_rxq_aligned_on_output(
+                        hypervisor_ip, metric_name, combined):
+                    LOG.warning(
+                        'PMD %s aligned with pmd-rxq-show on %s (attempt %s)',
+                        metric_name, hypervisor_ip, attempt + 1)
+                    return
+                self.fail(
+                    '%s on %s: no pmd-rxq-show series matched live :9105 '
+                    'within tolerance %s' % (
+                        metric_name, hypervisor_ip,
+                        self._pmd_gauge_tolerance()))
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for PMD %s on %s: %s',
+                    attempt + 1, METRIC_RETRY_ATTEMPTS, metric_name,
+                    hypervisor_ip, exc)
+            if attempt < METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(METRIC_RETRY_INTERVAL)
+        if last_exc is not None:
+            raise last_exc
+        self.fail(
+            'Timed out waiting for PMD %s on %s to match pmd-rxq-show' % (
+                metric_name, hypervisor_ip))
+
+    def _assert_pmd_rxq_metric_reported(self, metric_name):
+        """Assert ovs_pmd_cpu_overhead/rxq_usage via show and pmd-rxq-show."""
+        self._assert_ovs_interface_metric_reported(metric_name)
+        hypervisors = self._get_ssh_hypervisors('')
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisors available for PMD metric %s' % metric_name)
+        pmd_hypervisors = self._hypervisors_with_pmd_rxq(hypervisors)
+        self.assertNotEmpty(
+            pmd_hypervisors,
+            'No DPDK pmd-rxq-show output on hypervisors %s for %s' % (
+                hypervisors, metric_name))
+        last_exc = None
+        for hypervisor_ip in pmd_hypervisors:
+            try:
+                self._assert_pmd_rxq_matches_show(
+                    hypervisor_ip, metric_name)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'PMD rxq-show check failed on %s for %s: %s',
+                    hypervisor_ip, metric_name, exc)
+        self.fail(
+            'PMD metric %s did not match pmd-rxq-show on any hypervisor %s; '
+            'last error: %s' % (metric_name, pmd_hypervisors, last_exc))
+
+    def _max_rxq_usage_percent(self, hypervisor_ip, output=None):
+        """Return peak RxQ usage percent from pmd-rxq-show and live :9105."""
+        if output is None:
+            output = self._pmd_rxq_and_live_output(hypervisor_ip)
+        _overhead, rxq_usage = self._ovs_pmd_rxq_stats(
+            hypervisor_ip, output=output)
+        live_samples = self._parse_prom_float_samples(
+            output, OVS_PMD_RXQ_USAGE_METRIC)
+        values = list(rxq_usage.values())
+        values.extend(sample['value'] for sample in live_samples)
+        return max(values) if values else 0.0
 
     def _assert_metric_on_compute_scrape(self, metric_name):
         """Verify metric_name is exported on at least one compute :9105 scrape."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -206,6 +206,7 @@ PMD_RXQ_SHOW_COMMANDS = (
     'ovs-appctl dpif-netdev/pmd-rxq-show 2>/dev/null',
 )
 MEMORY_COUNT_RE = re.compile(r'(\w+):(\d+)')
+MEMORY_METRICS_DELIMITER = '---NETWORK_EXPORTER_METRICS---'
 MEMORY_SHOW_COMMANDS = (
     'sudo ovs-appctl memory/show 2>/dev/null',
     'ovs-appctl memory/show 2>/dev/null',
@@ -1578,20 +1579,33 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
     def _memory_show_and_live_output(self, hypervisor_ip):
         """Fetch memory/show and :9105 metrics in one SSH round-trip."""
         cmd = (
-            'sudo ovs-appctl memory/show 2>/dev/null || '
-            'ovs-appctl memory/show 2>/dev/null; '
-            'curl -sk https://127.0.0.1:9105/metrics 2>/dev/null || '
-            'curl -s http://127.0.0.1:9105/metrics 2>/dev/null')
+            "MEMORY_SHOW=$(sudo ovs-appctl memory/show 2>/dev/null || "
+            "ovs-appctl memory/show 2>/dev/null); "
+            "printf '%%s\\n%s\\n' \"$MEMORY_SHOW\" '%s'; "
+            "curl -sk https://127.0.0.1:9105/metrics 2>/dev/null || "
+            "curl -s http://127.0.0.1:9105/metrics 2>/dev/null"
+            % (MEMORY_METRICS_DELIMITER, MEMORY_METRICS_DELIMITER))
         return self._ssh_run_on_hypervisor(hypervisor_ip, cmd, check_rc=False)
 
-    def _hypervisors_with_memory_show(self, hypervisors):
+    def _split_memory_show_and_metrics(self, combined_output):
+        """Split combined SSH output into memory/show text and :9105 scrape."""
+        if MEMORY_METRICS_DELIMITER in (combined_output or ''):
+            show_output, metrics_output = combined_output.split(
+                MEMORY_METRICS_DELIMITER, 1)
+            return show_output.strip(), metrics_output.strip()
+        return (combined_output or '').strip(), ''
+
+    def _hypervisors_with_memory_show(self, hypervisors, show_key=None):
         """Return hypervisors that export memory/show stats."""
         found = []
         for hypervisor_ip in hypervisors:
             try:
                 stats = self._ovs_memory_show_stats(hypervisor_ip)
-                if stats:
-                    found.append(hypervisor_ip)
+                if not stats:
+                    continue
+                if show_key and show_key not in stats:
+                    continue
+                found.append(hypervisor_ip)
             except Exception as exc:
                 LOG.warning(
                     'No memory/show on %s: %s', hypervisor_ip, exc)
@@ -1605,16 +1619,23 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         last_exc = None
         for attempt in range(METRIC_RETRY_ATTEMPTS):
             combined = self._memory_show_and_live_output(hypervisor_ip)
+            show_output, metrics_output = self._split_memory_show_and_metrics(
+                combined)
+            if not show_output:
+                show_output = self._ovs_memory_show_output(hypervisor_ip)
+            if not metrics_output:
+                metrics_output = self._scrape_compute_metrics_text(
+                    hypervisor_ip)
             stats = self._ovs_memory_show_stats(
-                hypervisor_ip, output=combined)
+                hypervisor_ip, output=show_output)
             expected = stats.get(show_key)
             reported = self._memory_live_metric_value(
-                hypervisor_ip, metric_name, metrics_output=combined)
+                hypervisor_ip, metric_name, metrics_output=metrics_output)
             try:
                 self.assertIsNotNone(
                     expected,
-                    'memory/show missing %s on %s' % (
-                        show_key, hypervisor_ip))
+                    'memory/show missing %s on %s (show output: %r)' % (
+                        show_key, hypervisor_ip, show_output[:300]))
                 self.assertIsNotNone(
                     reported,
                     '%s missing on live :9105 on %s' % (
@@ -1652,11 +1673,13 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             hypervisors,
             'No compute hypervisors available for memory metric %s' % (
                 metric_name))
-        memory_hypervisors = self._hypervisors_with_memory_show(hypervisors)
+        show_key = OVS_MEMORY_METRIC_TO_SHOW_KEY[metric_name]
+        memory_hypervisors = self._hypervisors_with_memory_show(
+            hypervisors, show_key=show_key)
         self.assertNotEmpty(
             memory_hypervisors,
-            'No memory/show output on hypervisors %s for %s' % (
-                hypervisors, metric_name))
+            'No memory/show %s on hypervisors %s for %s' % (
+                show_key, hypervisors, metric_name))
         last_exc = None
         for hypervisor_ip in memory_hypervisors:
             try:

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -59,6 +59,18 @@ OVS_INTERFACE_STAT_TO_METRIC = {
     'rx_bytes': OVS_INTERFACE_RX_BYTES_METRIC,
     'tx_bytes': OVS_INTERFACE_TX_BYTES_METRIC,
 }
+OVS_INTERFACE_RX_ERRORS_METRIC = 'ovs_interface_rx_errors'
+OVS_INTERFACE_RX_DROPPED_METRIC = 'ovs_interface_rx_dropped'
+OVS_INTERFACE_TX_ERRORS_METRIC = 'ovs_interface_tx_errors'
+OVS_INTERFACE_TX_RETRIES_METRIC = 'ovs_interface_tx_retries'
+OVS_INTERFACE_ERROR_STAT_TO_METRIC = {
+    'rx_errors': OVS_INTERFACE_RX_ERRORS_METRIC,
+    'rx_dropped': OVS_INTERFACE_RX_DROPPED_METRIC,
+    'tx_errors': OVS_INTERFACE_TX_ERRORS_METRIC,
+    'tx_retries': OVS_INTERFACE_TX_RETRIES_METRIC,
+}
+OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC = 'ovnc_router_port_traffic_pkts'
+OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC = 'ovnc_router_port_traffic_bytes'
 NET_VF_INFO_METRIC = 'net_vf_info'
 NET_VF_RECEIVE_PACKETS_METRIC = 'net_vf_receive_packets_total'
 NET_VF_TRANSMIT_PACKETS_METRIC = 'net_vf_transmit_packets_total'
@@ -342,6 +354,116 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         else:
             detail = 'slow ping path failed'
         self.fail('Ping to %s failed: %s' % (dest_ip, detail))
+
+    def _guest_sudo_prefix(self, ssh_client):
+        """Return sudo -n prefix when passwordless sudo is available."""
+        return 'sudo -n' if self._guest_has_passwordless_sudo(ssh_client) else ''
+
+    def _run_guest_python_script(self, ssh_client, script, timeout_sec=60):
+        """Run a Python script on the guest via base64 pipe (avoids quoting)."""
+        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
+        cmd = 'timeout %d sh -c \'echo %s | base64 -d | python3\'' % (
+            timeout_sec, encoded)
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if sudo:
+            cmd = '%s %s' % (sudo, cmd)
+        return ssh_client.exec_command(cmd)
+
+    def _send_ping_packets_bound(self, ssh_client, bind_ip, dest_ip, count,
+                                 min_packets):
+        """Send ICMP echo requests bound to a specific source address."""
+        errors = []
+        if self._guest_has_passwordless_sudo(ssh_client):
+            for template in (
+                    'timeout %d sudo -n ping -c %d -I %s -i %g -W 2 %s',
+                    'ping -c %d -I %s -i %g -W 2 %s'):
+                if 'sudo' in template:
+                    wall = max(30, int(count * PING_FAST_INTERVAL_SEC) + 15)
+                    cmd = template % (
+                        wall, count, bind_ip, PING_FAST_INTERVAL_SEC, dest_ip)
+                else:
+                    cmd = template % (
+                        count, bind_ip, PING_FAST_INTERVAL_SEC, dest_ip)
+                LOG.warning('Sending bound ping: %s', cmd)
+                try:
+                    output = ssh_client.exec_command(cmd)
+                except Exception as exc:
+                    errors.append('%s -> %s' % (cmd, exc))
+                    continue
+                if '100% packet loss' not in (output or ''):
+                    return output
+                errors.append('%s -> 100%% packet loss' % cmd)
+        wall = min(PING_MAX_WALL_SECONDS,
+                   max(30, int(count * PING_SLOW_INTERVAL_SEC) + 15))
+        capped = min(count, int(wall / PING_SLOW_INTERVAL_SEC))
+        if capped < min_packets:
+            self.fail(
+                'Bound ping count %d below minimum %d without passwordless '
+                'sudo (cap %d at %gs interval)' % (
+                    capped, min_packets, capped, PING_SLOW_INTERVAL_SEC))
+        cmd = 'timeout %d ping -c %d -I %s -i %g -W 2 %s' % (
+            wall, capped, bind_ip, PING_SLOW_INTERVAL_SEC, dest_ip)
+        LOG.warning('Sending bound ping (slow path): %s', cmd)
+        try:
+            output = ssh_client.exec_command(cmd)
+        except Exception as exc:
+            errors.append('%s -> %s' % (cmd, exc))
+        else:
+            if '100% packet loss' not in (output or ''):
+                return output
+            errors.append('%s -> 100%% packet loss' % cmd)
+        detail = '; '.join(errors) if errors else 'bound ping failed'
+        self.fail('Ping from %s to %s failed: %s' % (bind_ip, dest_ip, detail))
+
+    def _assert_ovs_interface_metric_reported(self, metric_name):
+        """Assert metric on openstack metric show, compute :9105, metric-storage."""
+        stdout, stderr, returncode = self._metric_show(metric_name)
+        stdout = stdout or ''
+        if self._metric_show_output_usable(metric_name, stdout):
+            LOG.info(
+                "Metric '%s' reported via openstack metric show or "
+                "metric-storage fallback", metric_name)
+        else:
+            LOG.warning(
+                "openstack metric show unavailable for '%s' (exit %s: %s); "
+                "falling back to compute :9105 SSH scrape",
+                metric_name, returncode, stderr)
+            self._assert_metric_on_compute_scrape(metric_name)
+        storage_samples, query_error = self._metric_storage_samples(metric_name)
+        self.assertNotEmpty(
+            storage_samples,
+            '%s missing from metric-storage Prometheus (query: %s)' % (
+                metric_name, query_error))
+
+    def _assert_router_port_metric_reported(self, metric_name):
+        """Assert ovnc_router_port_traffic_* on compute :9105 and metric-storage."""
+        self._assert_metric_on_compute_scrape(metric_name)
+        storage_samples, query_error = self._metric_storage_samples(metric_name)
+        self.assertNotEmpty(
+            storage_samples,
+            '%s missing from metric-storage Prometheus (query: %s)' % (
+                metric_name, query_error))
+
+    def _router_port_label_key(self, labels):
+        """Stable identity for ovnc_router_port_traffic series."""
+        return (labels.get('datapath'), labels.get('port'))
+
+    def _prom_router_port_samples(self, hypervisor_ip, metric_name):
+        """Return all router-port metric samples from compute :9105."""
+        output = self._scrape_compute_metrics_text(hypervisor_ip)
+        return self._parse_prom_samples(output, metric_name)
+
+    def _router_port_sample_map(self, hypervisor_ip, metric_name, storage=False):
+        """Map (datapath, port) -> value from :9105 or metric-storage."""
+        if storage:
+            samples, _ = self._metric_storage_samples(
+                metric_name, hypervisor_ip=hypervisor_ip)
+        else:
+            samples = self._prom_router_port_samples(hypervisor_ip, metric_name)
+        return {
+            self._router_port_label_key(sample['labels']): sample['value']
+            for sample in samples
+        }
 
     def _assert_metric_on_compute_scrape(self, metric_name):
         """Verify metric_name is exported on at least one compute :9105 scrape."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -302,41 +302,60 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         return self.k8s_client.search_pods_using_regex(
             OVN_CONTROLLER_METRICS_POD_RE, OPENSTACK_NAMESPACE)
 
-    def _ovn_controller_metrics_pod_on_hypervisor(self, hypervisor_ip):
-        for pod in self._ovn_controller_metrics_pods():
-            node = (pod.get('spec') or {}).get('nodeName') or ''
-            if not node:
-                continue
-            node_short = node.split('.')[0]
-            for ident in self._hypervisor_identifiers(hypervisor_ip):
-                ident_short = ident.split('.')[0]
-                if (ident in node or node in ident or
-                        ident_short == node_short):
-                    return pod['metadata']['name']
-        return None
-
     def _scrape_ovn_controller_metrics_pod(self, hypervisor_ip=None):
         """Scrape ovn-controller-metrics :1981 via pod exec."""
         pod_name = None
+        pod_obj = None
         if hypervisor_ip:
-            pod_name = self._ovn_controller_metrics_pod_on_hypervisor(
-                hypervisor_ip)
+            for pod in self._ovn_controller_metrics_pods():
+                node = (pod.get('spec') or {}).get('nodeName') or ''
+                if not node:
+                    continue
+                node_short = node.split('.')[0]
+                for ident in self._hypervisor_identifiers(hypervisor_ip):
+                    ident_short = ident.split('.')[0]
+                    if (ident in node or node in ident or
+                            ident_short == node_short):
+                        pod_name = pod['metadata']['name']
+                        pod_obj = pod
+                        break
+                if pod_name:
+                    break
         if not pod_name:
             pods = self._ovn_controller_metrics_pods()
             if pods:
-                pod_name = pods[0]['metadata']['name']
+                pod_obj = pods[0]
+                pod_name = pod_obj['metadata']['name']
         if not pod_name:
             return ''
-        try:
-            return self.k8s_client.execute_command_in_pod(
-                pod_name, OPENSTACK_NAMESPACE,
-                OVN_CONTROLLER_METRICS_CONTAINER,
-                OVN_CONTROLLER_METRICS_CURL)
-        except Exception as exc:
+        containers = [
+            c.get('name') for c in (
+                (pod_obj or {}).get('spec') or {}).get('containers', [])
+            if c.get('name')]
+        if OVN_CONTROLLER_METRICS_CONTAINER in containers:
+            containers = [OVN_CONTROLLER_METRICS_CONTAINER] + [
+                c for c in containers
+                if c != OVN_CONTROLLER_METRICS_CONTAINER]
+        elif not containers:
+            containers = [OVN_CONTROLLER_METRICS_CONTAINER]
+        last_exc = None
+        for container in containers:
+            try:
+                output = self.k8s_client.execute_command_in_pod(
+                    pod_name, OPENSTACK_NAMESPACE, container,
+                    OVN_CONTROLLER_METRICS_CURL)
+                if output.strip():
+                    return output
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'ovn-controller-metrics scrape failed for pod %s '
+                    'container %s: %s', pod_name, container, exc)
+        if last_exc:
             LOG.warning(
                 'ovn-controller-metrics scrape failed for pod %s: %s',
-                pod_name, exc)
-            return ''
+                pod_name, last_exc)
+        return ''
 
     def _ovn_metric_scrape_outputs(self, hypervisor_ip=None):
         """Yield Prometheus text from OVN :1981 sources (node-local then pod)."""
@@ -348,33 +367,17 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         if pod_output.strip():
             yield ('ovn-controller-metrics', pod_output)
 
-    def _assert_metric_on_ovn_scrape(self, metric_name):
-        """Verify metric_name appears on an OVN :1981 scrape target."""
+    def _metric_on_ovn_scrape(self, metric_name):
+        """Return True when metric_name appears on a best-effort OVN :1981 scrape."""
         hypervisors = self._get_hypervisor_ip_from_undercloud()
-        self.assertNotEmpty(
-            hypervisors,
-            'No compute hypervisor IPs available for OVN :1981 scrape')
-        found_on = []
         for hypervisor_ip in hypervisors:
-            for source, output in self._ovn_metric_scrape_outputs(hypervisor_ip):
+            for _source, output in self._ovn_metric_scrape_outputs(hypervisor_ip):
                 for line in output.splitlines():
                     stripped = line.strip()
                     if stripped.startswith(metric_name + '{') or stripped.startswith(
                             metric_name + ' '):
-                        found_on.append('%s@%s' % (source, hypervisor_ip))
-                        break
-                if found_on:
-                    break
-            if found_on:
-                break
-        self.assertNotEmpty(
-            found_on,
-            "Metric '%s' not found on OVN :1981 scrape from hypervisors %s "
-            "(checked local :1981 and ovn-controller-metrics pods)" % (
-                metric_name, hypervisors))
-        LOG.warning(
-            "Metric '%s' found on OVN :1981 scrape from %s",
-            metric_name, found_on)
+                        return True
+        return False
 
     def _guest_has_passwordless_sudo(self, ssh_client):
         """Return True when the guest accepts ``sudo -n`` without prompting."""
@@ -524,21 +527,35 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 metric_name, query_error))
 
     def _assert_router_port_metric_reported(self, metric_name):
-        """Assert ovnc_router_port_traffic_* on OVN :1981 and metric-storage."""
+        """Assert ovnc_router_port_traffic_* via openstack metric show and storage."""
         self._assert_metric_reported(metric_name)
-        self._assert_metric_on_ovn_scrape(metric_name)
         storage_samples, query_error = self._metric_storage_samples(metric_name)
         self.assertNotEmpty(
             storage_samples,
             '%s missing from metric-storage Prometheus (query: %s)' % (
                 metric_name, query_error))
+        if not self._metric_on_ovn_scrape(metric_name):
+            LOG.warning(
+                '%s present in metric-storage but not on a Tempest-reachable '
+                'OVN :1981 scrape; router port tests use metric-storage',
+                metric_name)
 
     def _router_port_label_key(self, labels):
         """Stable identity for ovnc_router_port_traffic series."""
         return (labels.get('datapath'), labels.get('port'))
 
+    def _router_port_samples(self, hypervisor_ip, metric_name):
+        """Return router-port samples from metric-storage (RHOSO federation path)."""
+        samples, error = self._metric_storage_samples(metric_name)
+        if samples:
+            return samples
+        LOG.warning(
+            'No %s samples in metric-storage (%s); trying live OVN scrape',
+            metric_name, error)
+        return self._router_port_prom_samples(hypervisor_ip, metric_name)
+
     def _router_port_prom_samples(self, hypervisor_ip, metric_name):
-        """Return router-port samples from OVN :1981 (not compute :9105)."""
+        """Best-effort live scrape from OVN :1981 then compute :9105."""
         for _source, output in self._ovn_metric_scrape_outputs(hypervisor_ip):
             samples = self._parse_prom_samples(output, metric_name)
             if samples:
@@ -547,18 +564,15 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             self._scrape_compute_metrics_text(hypervisor_ip), metric_name)
 
     def _prom_router_port_samples(self, hypervisor_ip, metric_name):
-        """Return all router-port metric samples from OVN :1981."""
-        return self._router_port_prom_samples(hypervisor_ip, metric_name)
+        """Return router-port samples (metric-storage first)."""
+        return self._router_port_samples(hypervisor_ip, metric_name)
 
     def _router_port_sample_map(self, hypervisor_ip, metric_name, storage=False):
-        """Map (datapath, port) -> value from OVN :1981 or metric-storage."""
-        if storage:
-            samples, _ = self._metric_storage_samples(metric_name)
-        else:
-            samples = self._router_port_prom_samples(hypervisor_ip, metric_name)
+        """Map (datapath, port) -> value from metric-storage Prometheus."""
+        del storage  # kept for callers; router metrics always use storage
         return {
             self._router_port_label_key(sample['labels']): sample['value']
-            for sample in samples
+            for sample in self._router_port_samples(hypervisor_ip, metric_name)
         }
 
     def _assert_metric_on_compute_scrape(self, metric_name):

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -141,6 +141,9 @@ LEGACY_STATE_TEST_INTERFACES = (
 PING_FAST_INTERVAL_SEC = 0.001
 PING_SLOW_INTERVAL_SEC = 0.2
 PING_MAX_WALL_SECONDS = 120
+# Routed fast ping needs interval plus RTT per reply; 30s caps ~3k of 5k probes.
+PING_FAST_FLOOD_PER_PACKET_SEC = 0.01
+PING_FAST_FLOOD_MIN_WALL_SECONDS = 90
 
 
 class NetworkExporterMetricsBase(base_test.BaseTest):
@@ -387,6 +390,12 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         except Exception:
             return False
 
+    def _ping_fast_flood_wall_seconds(self, count):
+        """Wall-clock budget for ``ping -c N -i 0.001`` on routed networks."""
+        return max(
+            PING_FAST_FLOOD_MIN_WALL_SECONDS,
+            int(count * PING_FAST_FLOOD_PER_PACKET_SEC) + 30)
+
     def _send_ping_packets(self, ssh_client, dest_ip, count, min_packets):
         """Send ICMP echo requests between guests for traffic counter tests.
 
@@ -400,7 +409,7 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                     'timeout %d sudo -n ping -c %d -i %g -W 2 %s',
                     'ping -c %d -i %g -W 2 %s'):
                 if 'sudo' in template:
-                    wall = max(30, int(count * PING_FAST_INTERVAL_SEC) + 15)
+                    wall = self._ping_fast_flood_wall_seconds(count)
                     cmd = template % (
                         wall, count, PING_FAST_INTERVAL_SEC, dest_ip)
                 else:
@@ -469,7 +478,7 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                     'timeout %d sudo -n ping -c %d -I %s -i %g -W 2 %s',
                     'ping -c %d -I %s -i %g -W 2 %s'):
                 if 'sudo' in template:
-                    wall = max(30, int(count * PING_FAST_INTERVAL_SEC) + 15)
+                    wall = self._ping_fast_flood_wall_seconds(count)
                     cmd = template % (
                         wall, count, bind_ip, PING_FAST_INTERVAL_SEC, dest_ip)
                 else:

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -147,6 +147,8 @@ PING_FAST_FLOOD_MIN_WALL_SECONDS = 90
 # Tempest SSH exec often returns after ~30s; batch routed floods to stay under it.
 PING_FAST_BATCH_PACKETS = 600
 PING_FAST_BATCH_MAX_WALL_SECONDS = 25
+GUEST_PING_FLOOD_MARKER = '/tmp/tpst-router-ping.done'
+GUEST_PING_FLOOD_LOG = '/tmp/tpst-router-ping.log'
 
 
 class NetworkExporterMetricsBase(base_test.BaseTest):
@@ -477,6 +479,62 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         if sudo:
             cmd = '%s %s' % (sudo, cmd)
         return ssh_client.exec_command(cmd)
+
+    def _send_bound_ping_flood_on_guest(self, ssh_client, bind_ip, dest_ip,
+                                        count, min_packets):
+        """Run a bound ICMP flood on the guest outside Tempest SSH exec limits."""
+        batch = PING_FAST_BATCH_PACKETS
+        marker = GUEST_PING_FLOOD_MARKER
+        script = (
+            'import subprocess\n'
+            'bind = %r\n'
+            'dest = %r\n'
+            'total = %d\n'
+            'batch = %d\n'
+            'interval = %g\n'
+            'marker = %r\n'
+            'sent = 0\n'
+            'while sent < total:\n'
+            '    n = min(batch, total - sent)\n'
+            '    cmd = ["ping", "-c", str(n), "-I", bind, "-i", str(interval),\n'
+            '           "-W", "2", dest]\n'
+            '    proc = subprocess.run(cmd, capture_output=True, text=True)\n'
+            '    out = (proc.stdout or "") + (proc.stderr or "")\n'
+            '    if proc.returncode != 0 or "100%% packet loss" in out:\n'
+            '        break\n'
+            '    sent += n\n'
+            'open(marker, "w").write(str(sent))\n'
+            % (bind_ip, dest_ip, count, batch, PING_FAST_INTERVAL_SEC,
+               marker))
+        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
+        sudo = self._guest_sudo_prefix(ssh_client)
+        prefix = '%s ' % sudo if sudo else ''
+        start_cmd = (
+            "rm -f %s; nohup sh -c '%secho %s | base64 -d | python3' "
+            ">>%s 2>&1 &" % (marker, prefix, encoded, GUEST_PING_FLOOD_LOG))
+        LOG.warning(
+            'Starting guest background bound ping flood %s -> %s count %d',
+            bind_ip, dest_ip, count)
+        ssh_client.exec_command(start_cmd)
+        wall = max(180, int(count * PING_FAST_FLOOD_PER_PACKET_SEC) + 120)
+        deadline = time.time() + wall
+        while time.time() < deadline:
+            out = (ssh_client.exec_command(
+                'cat %s 2>/dev/null || true' % marker) or '').strip()
+            if out.isdigit():
+                sent = int(out)
+                LOG.warning(
+                    'Guest bound ping flood finished: %d/%d transmitted',
+                    sent, count)
+                if sent < min(min_packets, count):
+                    self.fail(
+                        'Guest bound ping flood sent %d packets (need >= %d)' %
+                        (sent, min_packets))
+                return sent
+            time.sleep(5)
+        self.fail(
+            'Timed out waiting for guest bound ping flood marker %s '
+            '(limit %ds)' % (marker, wall))
 
     def _send_ping_packets_bound(self, ssh_client, bind_ip, dest_ip, count,
                                  min_packets):

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -1151,9 +1151,10 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             'Could not get pmd-perf-show on %s (last output: %r)' % (
                 hypervisor_ip, (last_output or '')[:500]))
 
-    def _ovs_pmd_perf_stats_map(self, hypervisor_ip):
+    def _ovs_pmd_perf_stats_map(self, hypervisor_ip, output=None):
         """Map (numa, cpu) -> pmd-perf-show stat name -> value."""
-        output = self._pmd_perf_show_output(hypervisor_ip)
+        if output is None:
+            output = self._pmd_perf_show_output(hypervisor_ip)
         result = {}
         numa = cpu = None
         for line in output.splitlines():
@@ -1169,13 +1170,35 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 result[(numa, cpu)][stat.group(1).strip()] = int(stat.group(2))
         return result
 
+    def _pmd_perf_and_live_output(self, hypervisor_ip):
+        """Fetch pmd-perf-show and :9105 metrics in one SSH round-trip."""
+        cmd = (
+            'sudo ovs-appctl dpif-netdev/pmd-perf-show 2>/dev/null; '
+            'curl -sk https://127.0.0.1:9105/metrics 2>/dev/null || '
+            'curl -s http://127.0.0.1:9105/metrics 2>/dev/null')
+        return self._ssh_run_on_hypervisor(hypervisor_ip, cmd, check_rc=False)
+
+    def _pmd_alignment_allowed_delta(self, expected, reported):
+        pct = CONF.nfv_plugin_options.network_exporter_pmd_alignment_tolerance_pct
+        floor = CONF.nfv_plugin_options.network_exporter_pmd_alignment_min_delta
+        largest = max(abs(expected), abs(reported), 1)
+        return max(floor, int(largest * pct / 100.0))
+
+    def _pmd_values_aligned(self, expected, reported):
+        """PMD counters advance between perf-show and exporter reads."""
+        if expected == reported:
+            return True
+        return abs(expected - reported) <= self._pmd_alignment_allowed_delta(
+            expected, reported)
+
     def _pmd_thread_key(self, labels):
         return labels.get('numa'), labels.get('cpu')
 
-    def _pmd_live_samples(self, hypervisor_ip, metric_name):
+    def _pmd_live_samples(self, hypervisor_ip, metric_name, metrics_output=None):
         """Return all ovs_pmd_* samples from live :9105 on one hypervisor."""
-        return self._parse_prom_samples(
-            self._scrape_compute_metrics_text(hypervisor_ip), metric_name)
+        if metrics_output is None:
+            metrics_output = self._scrape_compute_metrics_text(hypervisor_ip)
+        return self._parse_prom_samples(metrics_output, metric_name)
 
     def _pmd_live_total(self, hypervisor_ip, metric_name):
         """Sum ovs_pmd_* across all PMD threads on one hypervisor."""
@@ -1211,10 +1234,13 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             stat_name, 'No pmd-perf-show mapping for metric %s' % metric_name)
         last_exc = None
         for attempt in range(METRIC_RETRY_ATTEMPTS):
-            perf_map = self._ovs_pmd_perf_stats_map(hypervisor_ip)
+            combined = self._pmd_perf_and_live_output(hypervisor_ip)
+            perf_map = self._ovs_pmd_perf_stats_map(
+                hypervisor_ip, output=combined)
             live_by_key = {
                 self._pmd_thread_key(sample['labels']): sample['value']
-                for sample in self._pmd_live_samples(hypervisor_ip, metric_name)
+                for sample in self._pmd_live_samples(
+                    hypervisor_ip, metric_name, metrics_output=combined)
             }
             try:
                 self.assertNotEmpty(
@@ -1224,7 +1250,6 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                     live_by_key,
                     '%s missing on live :9105 on %s' % (
                         metric_name, hypervisor_ip))
-                matched = False
                 for thread_key, stats in perf_map.items():
                     if stat_name not in stats:
                         continue
@@ -1232,17 +1257,21 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                     reported = live_by_key.get(thread_key)
                     if reported is None:
                         continue
-                    self.assertEqual(
-                        expected, reported,
-                        '%s on %s numa=%s cpu=%s: perf-show %s=%s live=%s' % (
+                    allowed = self._pmd_alignment_allowed_delta(
+                        expected, reported)
+                    self.assertTrue(
+                        self._pmd_values_aligned(expected, reported),
+                        '%s on %s numa=%s cpu=%s: perf-show %s=%s live=%s '
+                        '(delta %s, allowed %s)' % (
                             metric_name, hypervisor_ip, thread_key[0],
-                            thread_key[1], stat_name, expected, reported))
-                    matched = True
+                            thread_key[1], stat_name, expected, reported,
+                            abs(expected - reported), allowed))
                     LOG.warning(
                         'PMD %s aligned with pmd-perf-show on %s numa=%s '
-                        'cpu=%s (attempt %s): %s',
+                        'cpu=%s (attempt %s): perf=%s live=%s delta=%s',
                         metric_name, hypervisor_ip, thread_key[0],
-                        thread_key[1], attempt + 1, expected)
+                        thread_key[1], attempt + 1, expected, reported,
+                        abs(expected - reported))
                     return
                 self.fail(
                     '%s on %s: no pmd-perf-show thread matched live :9105 '

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import ipaddress
 import os
 import re
 import time
@@ -363,15 +364,47 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             return results, ''
         return [], error or 'metric-storage query failed'
 
+    @staticmethod
+    def _is_ip_literal(value):
+        """True when value is a bare IPv4/IPv6 address (not a hostname)."""
+        try:
+            ipaddress.ip_address(value)
+            return True
+        except ValueError:
+            return False
+
+    def _text_matches_hypervisor_identifier(self, text, ident):
+        """Match a hypervisor identifier against label/row text.
+
+        Do not derive short forms from IP addresses (e.g. 192.168.122.101
+        must not use '192' as a substring match — that collides with every
+        other 192.x compute). Hostname short forms require a token boundary
+        so 'compute-0' does not match 'compute-01'.
+        """
+        if not text or not ident:
+            return False
+        if self._is_ip_literal(ident):
+            # Match bare IP or Prometheus instance form IP:port. Never use the
+            # first dotted octet as a short form (that matches every 192.x host).
+            return bool(re.search(
+                r'(^|[^0-9.])%s(:\d+)?(?=[^0-9.]|$)' % re.escape(ident),
+                text))
+        if ident in text:
+            return True
+        short = ident.split('.')[0]
+        if not short or short == ident:
+            return False
+        return bool(re.search(
+            r'(^|[^A-Za-z0-9-])%s([^A-Za-z0-9-]|$)' % re.escape(short),
+            text))
+
     def _sample_matches_hypervisor(self, labels, hypervisor_ip):
         """True when a metric-storage sample belongs to hypervisor_ip."""
         row_text = ' '.join(
             labels.get(key, '') for key in ('instance', 'fqdn', 'hostname'))
-        for ident in self._hypervisor_identifiers(hypervisor_ip):
-            ident_short = ident.split('.')[0]
-            if ident in row_text or ident_short in row_text:
-                return True
-        return False
+        return any(
+            self._text_matches_hypervisor_identifier(row_text, ident)
+            for ident in self._hypervisor_identifiers(hypervisor_ip))
 
     def _metric_storage_samples(self, metric_name, hypervisor_ip=None,
                                 required_labels=None):
@@ -449,9 +482,16 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                     continue
                 node_short = node.split('.')[0]
                 for ident in self._hypervisor_identifiers(hypervisor_ip):
+                    if self._is_ip_literal(ident):
+                        # nodeName is normally a hostname; only match exact IP.
+                        if ident == node:
+                            pod_name = pod['metadata']['name']
+                            pod_obj = pod
+                            break
+                        continue
                     ident_short = ident.split('.')[0]
-                    if (ident in node or node in ident or
-                            ident_short == node_short):
+                    if (ident == node or ident in node or node in ident or
+                            (ident_short and ident_short == node_short)):
                         pod_name = pod['metadata']['name']
                         pod_obj = pod
                         break
@@ -2299,12 +2339,14 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         if not self._row_is_compute_network_exporter(parts):
             return False
         row_text = ' '.join(parts)
-        return any(identifier in row_text
-                   for identifier in self._hypervisor_identifiers(hypervisor_ip))
+        return any(
+            self._text_matches_hypervisor_identifier(row_text, identifier)
+            for identifier in self._hypervisor_identifiers(hypervisor_ip))
 
     def _line_matches_hypervisor(self, line, hypervisor_ip):
-        return any(identifier in line
-                   for identifier in self._hypervisor_identifiers(hypervisor_ip))
+        return any(
+            self._text_matches_hypervisor_identifier(line, identifier)
+            for identifier in self._hypervisor_identifiers(hypervisor_ip))
 
     def _is_ovn_k8s_metrics_row(self, line):
         """True for OVN metrics scraped via openstack.svc:1981 (not compute)."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -397,11 +397,6 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         return samples, error
 
     def _metric_show_output_usable(self, metric_name, stdout):
-        """True when pod exec or PromQL output contains metric_name samples."""
-        stdout = stdout or ''
-        return bool(stdout.strip()) and metric_name in stdout
-
-    def _metric_show_output_usable(self, metric_name, stdout):
         """True when PromQL output contains metric_name samples."""
         stdout = stdout or ''
         return bool(stdout.strip()) and metric_name in stdout

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -757,6 +757,116 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         """Stable identity for ovs_datapath_* series."""
         return labels.get('name') or labels.get('datapath')
 
+    def _datapath_headers_from_output(self, output):
+        """Return type/name pairs from dpctl/show headers."""
+        headers = []
+        for line in (output or '').splitlines():
+            header = DPCTL_DATAPATH_HEADER_RE.match(line)
+            if header:
+                headers.append({
+                    'type': header.group(1),
+                    'name': header.group(2),
+                })
+        return headers
+
+    def _datapath_headers_on_hypervisor(self, hypervisor_ip):
+        return self._datapath_headers_from_output(
+            self._ovs_datapath_dpctl_show_output(hypervisor_ip))
+
+    def _datapath_header_matches(self, headers, name, datapath_type=None):
+        for header in headers:
+            if header['name'] != name:
+                continue
+            if datapath_type and header['type'] != datapath_type:
+                continue
+            return True
+        return False
+
+    def _datapath_unfiltered_samples(self, hypervisor_ip, metric_name):
+        """Return all ovs_datapath_* samples for one hypervisor."""
+        samples, _error = self._metric_storage_samples(
+            metric_name, hypervisor_ip=hypervisor_ip)
+        if samples:
+            return samples
+        return self._parse_prom_samples(
+            self._scrape_compute_metrics_text(hypervisor_ip), metric_name)
+
+    def _sample_datapath_labels(self, labels):
+        """Extract type/name labels from a Prometheus sample."""
+        name = labels.get('name') or labels.get('datapath')
+        if not name:
+            return None
+        resolved = {'name': name}
+        dtype = labels.get('type')
+        if dtype:
+            resolved['type'] = dtype
+        return resolved
+
+    def _resolve_datapath_labels(self, hypervisor_ip, metric_name=None):
+        """Pick datapath type/name present in both exporter and dpctl/show."""
+        metric_name = metric_name or OVS_DATAPATH_FLOWS_TOTAL_METRIC
+        cache = getattr(self, '_datapath_label_cache', None)
+        if cache is None:
+            cache = {}
+            self._datapath_label_cache = cache
+        cache_key = (hypervisor_ip, metric_name)
+        if cache_key in cache:
+            return dict(cache[cache_key])
+
+        configured_name = self._configured_datapath_name()
+        configured_type = self._configured_datapath_type()
+        headers = self._datapath_headers_on_hypervisor(hypervisor_ip)
+        sample_labels = []
+        for sample in self._datapath_unfiltered_samples(
+                hypervisor_ip, metric_name):
+            labels = self._sample_datapath_labels(sample['labels'])
+            if labels and labels not in sample_labels:
+                sample_labels.append(labels)
+
+        resolved = None
+        if self._datapath_header_matches(
+                headers, configured_name, configured_type):
+            resolved = {
+                'name': configured_name,
+                'type': configured_type,
+            }
+        elif self._datapath_header_matches(headers, configured_name):
+            resolved = next(
+                header for header in headers
+                if header['name'] == configured_name)
+        else:
+            for candidate in sample_labels:
+                if self._datapath_header_matches(
+                        headers, candidate['name'],
+                        candidate.get('type')):
+                    resolved = dict(candidate)
+                    break
+            if resolved is None and len(headers) == 1:
+                resolved = dict(headers[0])
+            elif resolved is None and sample_labels:
+                resolved = dict(sample_labels[0])
+
+        if resolved is None:
+            self.fail(
+                'Could not resolve ovs_datapath type/name on %s. '
+                'dpctl/show headers: %s; metric samples: %s; configured '
+                '%s@%s' % (
+                    hypervisor_ip,
+                    ['%s@%s' % (h['type'], h['name']) for h in headers],
+                    sample_labels,
+                    configured_type, configured_name))
+
+        if (resolved['name'] != configured_name or
+                resolved.get('type') != configured_type):
+            LOG.warning(
+                'Using datapath %s@%s on %s (configured %s@%s not in '
+                'dpctl/show)',
+                resolved.get('type'), resolved['name'], hypervisor_ip,
+                configured_type, configured_name)
+
+        cache[cache_key] = dict(resolved)
+        return dict(resolved)
+
     def _ovs_datapath_dpctl_show_output(self, hypervisor_ip):
         """Fetch dpctl/show text (same source as openstack-network-exporter)."""
         last_output = ''
@@ -820,8 +930,12 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
     def _datapath_samples(self, hypervisor_ip, metric_name, datapath=None,
                           datapath_type=None):
         """Return datapath samples from metric-storage for one hypervisor."""
-        required_labels = self._datapath_required_labels(
-            datapath=datapath, datapath_type=datapath_type)
+        if datapath is None and datapath_type is None:
+            required_labels = self._resolve_datapath_labels(
+                hypervisor_ip, metric_name)
+        else:
+            required_labels = self._datapath_required_labels(
+                datapath=datapath, datapath_type=datapath_type)
         samples, error = self._metric_storage_samples(
             metric_name, hypervisor_ip=hypervisor_ip,
             required_labels=required_labels)
@@ -852,6 +966,11 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
     def _datapath_metric_value(self, hypervisor_ip, metric_name, datapath=None,
                                datapath_type=None):
         """Return a single datapath series value for hypervisor_ip."""
+        if datapath is None and datapath_type is None:
+            labels = self._resolve_datapath_labels(
+                hypervisor_ip, metric_name)
+            datapath = labels['name']
+            datapath_type = labels.get('type')
         sample_map = self._datapath_sample_map(
             hypervisor_ip, metric_name, datapath=datapath,
             datapath_type=datapath_type)
@@ -865,7 +984,6 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
     def _assert_datapath_metric_reported(self, metric_name):
         """Assert ovs_datapath_* via metric show, :9105, and metric-storage."""
         self._assert_ovs_interface_metric_reported(metric_name)
-        datapath = self._configured_datapath_name()
         hypervisors = self._get_ssh_hypervisors('')
         self.assertNotEmpty(
             hypervisors,
@@ -875,7 +993,7 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         for hypervisor_ip in hypervisors:
             try:
                 self._assert_datapath_matches_dpctl(
-                    hypervisor_ip, metric_name, datapath)
+                    hypervisor_ip, metric_name)
                 return
             except Exception as exc:
                 last_exc = exc
@@ -887,26 +1005,37 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             '%s; last error: %s' % (metric_name, hypervisors, last_exc))
 
     def _assert_datapath_matches_dpctl(self, hypervisor_ip, metric_name,
-                                       datapath=None):
+                                       datapath=None, datapath_type=None):
         """Assert exporter datapath metric matches ovs-dpctl on the hypervisor."""
-        datapath = datapath or self._configured_datapath_name()
+        if datapath is None and datapath_type is None:
+            labels = self._resolve_datapath_labels(
+                hypervisor_ip, metric_name)
+            datapath = labels['name']
+            datapath_type = labels.get('type')
+        else:
+            datapath = datapath or self._configured_datapath_name()
+            if datapath_type is None:
+                datapath_type = self._configured_datapath_type()
         dpctl_key = OVS_DATAPATH_METRIC_TO_DPCTL_KEY.get(metric_name)
         self.assertIsNotNone(
             dpctl_key,
             'No dpctl mapping for datapath metric %s' % metric_name)
-        dpctl_stats = self._ovs_datapath_dpctl_stats(hypervisor_ip, datapath)
+        dpctl_stats = self._ovs_datapath_dpctl_stats(
+            hypervisor_ip, datapath, datapath_type=datapath_type)
         expected = dpctl_stats[dpctl_key]
         reported = self._datapath_metric_value(
-            hypervisor_ip, metric_name, datapath=datapath)
+            hypervisor_ip, metric_name, datapath=datapath,
+            datapath_type=datapath_type)
+        datapath_label = '%s@%s' % (datapath_type or '*', datapath)
         self.assertIsNotNone(
             reported,
             '%s missing for datapath %s on %s' % (
-                metric_name, datapath, hypervisor_ip))
+                metric_name, datapath_label, hypervisor_ip))
         self.assertEqual(
             expected, reported,
             '%s on %s datapath %s: dpctl %s=%s exporter=%s' % (
-                metric_name, hypervisor_ip, datapath, dpctl_key, expected,
-                reported))
+                metric_name, hypervisor_ip, datapath_label, dpctl_key,
+                expected, reported))
 
     def _assert_metric_on_compute_scrape(self, metric_name):
         """Verify metric_name is exported on at least one compute :9105 scrape."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -101,6 +101,25 @@ OVS_PMD_CPU_USAGE_METRICS = (
     OVS_PMD_CPU_OVERHEAD_METRIC,
     OVS_PMD_RXQ_USAGE_METRIC,
 )
+OVS_MEMORY_HANDLERS_TOTAL_METRIC = 'ovs_memory_handlers_total'
+OVS_MEMORY_PORTS_TOTAL_METRIC = 'ovs_memory_ports_total'
+OVS_MEMORY_REVALIDATORS_TOTAL_METRIC = 'ovs_memory_revalidators_total'
+OVS_MEMORY_RULES_TOTAL_METRIC = 'ovs_memory_rules_total'
+OVS_MEMORY_KEYS_TOTAL_METRIC = 'ovs_memory_keys_total'
+OVS_MEMORY_METRICS = (
+    OVS_MEMORY_HANDLERS_TOTAL_METRIC,
+    OVS_MEMORY_PORTS_TOTAL_METRIC,
+    OVS_MEMORY_REVALIDATORS_TOTAL_METRIC,
+    OVS_MEMORY_RULES_TOTAL_METRIC,
+    OVS_MEMORY_KEYS_TOTAL_METRIC,
+)
+OVS_MEMORY_METRIC_TO_SHOW_KEY = {
+    OVS_MEMORY_HANDLERS_TOTAL_METRIC: 'handlers',
+    OVS_MEMORY_PORTS_TOTAL_METRIC: 'ports',
+    OVS_MEMORY_REVALIDATORS_TOTAL_METRIC: 'revalidators',
+    OVS_MEMORY_RULES_TOTAL_METRIC: 'rules',
+    OVS_MEMORY_KEYS_TOTAL_METRIC: 'keys',
+}
 OVS_PMD_METRIC_TO_PERF_STAT = {
     OVS_PMD_TOTAL_ITERATIONS_METRIC: 'Iterations',
     OVS_PMD_IDLE_ITERATIONS_METRIC: '- idle iterations',
@@ -185,6 +204,11 @@ PMD_PERF_SHOW_COMMANDS = (
 PMD_RXQ_SHOW_COMMANDS = (
     'sudo ovs-appctl dpif-netdev/pmd-rxq-show 2>/dev/null',
     'ovs-appctl dpif-netdev/pmd-rxq-show 2>/dev/null',
+)
+MEMORY_COUNT_RE = re.compile(r'(\w+):(\d+)')
+MEMORY_SHOW_COMMANDS = (
+    'sudo ovs-appctl memory/show 2>/dev/null',
+    'ovs-appctl memory/show 2>/dev/null',
 )
 PMD_RXQ_OVERHEAD_RE = re.compile(r'^\s*overhead\s*:\s*([\d.]+)\s*%$')
 PMD_RXQ_USAGE_RE = re.compile(
@@ -1517,6 +1541,137 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         self.fail(
             'PMD metric %s did not match pmd-rxq-show on any hypervisor %s; '
             'last error: %s' % (metric_name, pmd_hypervisors, last_exc))
+
+    def _ovs_memory_show_output(self, hypervisor_ip):
+        """Fetch ovs-appctl memory/show text (same source as network-exporter)."""
+        last_output = ''
+        for cmd in MEMORY_SHOW_COMMANDS:
+            output = self._ssh_run_on_hypervisor(
+                hypervisor_ip, cmd, check_rc=False)
+            if output and output.strip():
+                return output
+            last_output = output or last_output
+        self.fail(
+            'Could not get memory/show output on %s (last output: %r)' % (
+                hypervisor_ip, (last_output or '')[:500]))
+
+    def _ovs_memory_show_stats(self, hypervisor_ip, output=None):
+        """Parse memory/show counts for known exporter keys only."""
+        if output is None:
+            output = self._ovs_memory_show_output(hypervisor_ip)
+        known_keys = set(OVS_MEMORY_METRIC_TO_SHOW_KEY.values())
+        stats = {}
+        for match in MEMORY_COUNT_RE.finditer(output):
+            key = match.group(1)
+            if key in known_keys:
+                stats[key] = int(match.group(2))
+        return stats
+
+    def _memory_live_metric_value(self, hypervisor_ip, metric_name,
+                                  metrics_output=None):
+        """Read one unlabeled ovs_memory_* gauge from a :9105 scrape."""
+        if metrics_output is None:
+            metrics_output = self._scrape_compute_metrics_text(hypervisor_ip)
+        return self._parse_prom_metric_text(
+            metrics_output, metric_name, {})
+
+    def _memory_show_and_live_output(self, hypervisor_ip):
+        """Fetch memory/show and :9105 metrics in one SSH round-trip."""
+        cmd = (
+            'sudo ovs-appctl memory/show 2>/dev/null || '
+            'ovs-appctl memory/show 2>/dev/null; '
+            'curl -sk https://127.0.0.1:9105/metrics 2>/dev/null || '
+            'curl -s http://127.0.0.1:9105/metrics 2>/dev/null')
+        return self._ssh_run_on_hypervisor(hypervisor_ip, cmd, check_rc=False)
+
+    def _hypervisors_with_memory_show(self, hypervisors):
+        """Return hypervisors that export memory/show stats."""
+        found = []
+        for hypervisor_ip in hypervisors:
+            try:
+                stats = self._ovs_memory_show_stats(hypervisor_ip)
+                if stats:
+                    found.append(hypervisor_ip)
+            except Exception as exc:
+                LOG.warning(
+                    'No memory/show on %s: %s', hypervisor_ip, exc)
+        return found
+
+    def _assert_memory_matches_show(self, hypervisor_ip, metric_name):
+        """Assert live :9105 ovs_memory_* equals memory/show on hypervisor."""
+        show_key = OVS_MEMORY_METRIC_TO_SHOW_KEY.get(metric_name)
+        self.assertIsNotNone(
+            show_key, 'No memory/show mapping for metric %s' % metric_name)
+        last_exc = None
+        for attempt in range(METRIC_RETRY_ATTEMPTS):
+            combined = self._memory_show_and_live_output(hypervisor_ip)
+            stats = self._ovs_memory_show_stats(
+                hypervisor_ip, output=combined)
+            expected = stats.get(show_key)
+            reported = self._memory_live_metric_value(
+                hypervisor_ip, metric_name, metrics_output=combined)
+            try:
+                self.assertIsNotNone(
+                    expected,
+                    'memory/show missing %s on %s' % (
+                        show_key, hypervisor_ip))
+                self.assertIsNotNone(
+                    reported,
+                    '%s missing on live :9105 on %s' % (
+                        metric_name, hypervisor_ip))
+                self.assertEqual(
+                    expected, reported,
+                    '%s on %s: memory/show %s=%s live=%s' % (
+                        metric_name, hypervisor_ip, show_key,
+                        expected, reported))
+                LOG.warning(
+                    'Memory %s aligned with memory/show on %s (attempt %s): '
+                    'show=%s live=%s',
+                    metric_name, hypervisor_ip, attempt + 1,
+                    expected, reported)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for memory %s on %s: %s',
+                    attempt + 1, METRIC_RETRY_ATTEMPTS, metric_name,
+                    hypervisor_ip, exc)
+            if attempt < METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(METRIC_RETRY_INTERVAL)
+        if last_exc is not None:
+            raise last_exc
+        self.fail(
+            'Timed out waiting for memory %s on %s to match memory/show' % (
+                metric_name, hypervisor_ip))
+
+    def _assert_memory_metric_reported(self, metric_name):
+        """Assert ovs_memory_* via metric show, :9105, and memory/show."""
+        self._assert_ovs_interface_metric_reported(metric_name)
+        hypervisors = self._get_ssh_hypervisors('')
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisors available for memory metric %s' % (
+                metric_name))
+        memory_hypervisors = self._hypervisors_with_memory_show(hypervisors)
+        self.assertNotEmpty(
+            memory_hypervisors,
+            'No memory/show output on hypervisors %s for %s' % (
+                hypervisors, metric_name))
+        last_exc = None
+        for hypervisor_ip in memory_hypervisors:
+            try:
+                self._assert_memory_matches_show(
+                    hypervisor_ip, metric_name)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'memory/show check failed on %s for %s: %s',
+                    hypervisor_ip, metric_name, exc)
+        self.fail(
+            'Memory metric %s did not match memory/show on any hypervisor '
+            '%s; last error: %s' % (
+                metric_name, memory_hypervisors, last_exc))
 
     def _max_rxq_usage_percent(self, hypervisor_ip, output=None):
         """Return peak RxQ usage percent from pmd-rxq-show and live :9105."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -478,22 +478,51 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             cmd = '%s %s' % (sudo, cmd)
         return ssh_client.exec_command(cmd)
 
+    def _parse_ping_transmitted(self, output):
+        """Return ICMP probes transmitted per ping(8) statistics output."""
+        match = re.search(r'(\d+) packets transmitted', output or '')
+        return int(match.group(1)) if match else 0
+
+    def _bound_ping_cmd_output(self, ssh_client, cmd, accept_xmit_only=False):
+        """Run a bound ping command; optionally ignore non-zero ping exit status."""
+        run = '%s || true' % cmd if accept_xmit_only else cmd
+        try:
+            return ssh_client.exec_command(run) or ''
+        except Exception as exc:
+            if accept_xmit_only:
+                return str(exc)
+            raise
+
+    def _bound_ping_output_ok(self, output, min_packets,
+                              accept_xmit_only=False):
+        transmitted = self._parse_ping_transmitted(output)
+        if accept_xmit_only:
+            return transmitted >= min_packets, transmitted
+        if '100% packet loss' not in (output or ''):
+            return True, transmitted
+        return False, transmitted
+
     def _send_ping_packets_bound(self, ssh_client, bind_ip, dest_ip, count,
-                                 min_packets):
+                                 min_packets, accept_xmit_only=False):
         """Send ICMP echo requests bound to a specific source address."""
         if (count > PING_FAST_BATCH_PACKETS and
                 self._guest_has_passwordless_sudo(ssh_client)):
             return self._send_ping_packets_bound_batched(
-                ssh_client, bind_ip, dest_ip, count, min_packets)
+                ssh_client, bind_ip, dest_ip, count, min_packets,
+                accept_xmit_only=accept_xmit_only)
         return self._send_ping_packets_bound_once(
-            ssh_client, bind_ip, dest_ip, count, min_packets)
+            ssh_client, bind_ip, dest_ip, count, min_packets,
+            accept_xmit_only=accept_xmit_only)
 
     def _send_ping_packets_bound_batched(self, ssh_client, bind_ip, dest_ip,
-                                         count, min_packets):
+                                         count, min_packets,
+                                         accept_xmit_only=False):
         """Send a large bound ping flood in SSH-friendly batches."""
         remaining = count
         last_output = ''
+        total_xmit = 0
         batch_num = 0
+        batch_min = 1 if accept_xmit_only else min_packets
         while remaining > 0:
             batch_num += 1
             batch = min(PING_FAST_BATCH_PACKETS, remaining)
@@ -501,13 +530,20 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 'Bound ping batch %d: %d packets (%d remaining)',
                 batch_num, batch, remaining - batch)
             last_output = self._send_ping_packets_bound_once(
-                ssh_client, bind_ip, dest_ip, batch, min_packets=1,
-                fast_wall=self._ping_fast_batch_wall_seconds(batch))
+                ssh_client, bind_ip, dest_ip, batch, min_packets=batch_min,
+                fast_wall=self._ping_fast_batch_wall_seconds(batch),
+                accept_xmit_only=accept_xmit_only)
+            total_xmit += self._parse_ping_transmitted(last_output)
             remaining -= batch
+        if accept_xmit_only:
+            LOG.warning(
+                'Bound ping xmit-only flood: %d/%d transmitted %s -> %s',
+                total_xmit, count, bind_ip, dest_ip)
         return last_output
 
     def _send_ping_packets_bound_once(self, ssh_client, bind_ip, dest_ip, count,
-                                      min_packets, fast_wall=None):
+                                      min_packets, fast_wall=None,
+                                      accept_xmit_only=False):
         """Send one bound ping command (single SSH exec)."""
         errors = []
         if self._guest_has_passwordless_sudo(ssh_client):
@@ -524,16 +560,25 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                         count, bind_ip, PING_FAST_INTERVAL_SEC, dest_ip)
                 LOG.warning('Sending bound ping: %s', cmd)
                 try:
-                    output = ssh_client.exec_command(cmd)
+                    output = self._bound_ping_cmd_output(
+                        ssh_client, cmd, accept_xmit_only=accept_xmit_only)
                 except Exception as exc:
                     errors.append('%s -> %s' % (cmd, exc))
                     continue
-                if '100% packet loss' not in (output or ''):
+                ok, transmitted = self._bound_ping_output_ok(
+                    output, min_packets, accept_xmit_only=accept_xmit_only)
+                if ok:
+                    if accept_xmit_only:
+                        LOG.warning(
+                            'Bound ping xmit-only OK: %d transmitted %s -> %s',
+                            transmitted, bind_ip, dest_ip)
                     return output
-                errors.append('%s -> 100%% packet loss' % cmd)
+                errors.append(
+                    '%s -> xmit %d (need >= %d)' % (cmd, transmitted,
+                                                    min_packets))
         capped = min(count, int(PING_MAX_WALL_SECONDS /
                                  PING_SLOW_INTERVAL_SEC))
-        if capped < min_packets:
+        if capped < min_packets and not accept_xmit_only:
             LOG.warning(
                 'Bound ping capped at %d without passwordless sudo '
                 '(requested min %d); using capped count at %gs interval',
@@ -544,13 +589,18 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             wall, capped, bind_ip, PING_SLOW_INTERVAL_SEC, dest_ip)
         LOG.warning('Sending bound ping (slow path): %s', cmd)
         try:
-            output = ssh_client.exec_command(cmd)
+            output = self._bound_ping_cmd_output(
+                ssh_client, cmd, accept_xmit_only=accept_xmit_only)
         except Exception as exc:
             errors.append('%s -> %s' % (cmd, exc))
         else:
-            if '100% packet loss' not in (output or ''):
+            ok, transmitted = self._bound_ping_output_ok(
+                output, min_packets, accept_xmit_only=accept_xmit_only)
+            if ok:
                 return output
-            errors.append('%s -> 100%% packet loss' % cmd)
+            errors.append(
+                '%s -> xmit %d (need >= %d)' % (cmd, transmitted,
+                                                min_packets))
         detail = '; '.join(errors) if errors else 'bound ping failed'
         self.fail('Ping from %s to %s failed: %s' % (bind_ip, dest_ip, detail))
 

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -484,15 +484,15 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 if '100% packet loss' not in (output or ''):
                     return output
                 errors.append('%s -> 100%% packet loss' % cmd)
-        wall = min(PING_MAX_WALL_SECONDS,
-                   max(30, int(count * PING_SLOW_INTERVAL_SEC) + 15))
-        capped = min(count, int(wall / PING_SLOW_INTERVAL_SEC))
+        capped = min(count, int(PING_MAX_WALL_SECONDS /
+                                 PING_SLOW_INTERVAL_SEC))
         if capped < min_packets:
             LOG.warning(
                 'Bound ping capped at %d without passwordless sudo '
                 '(requested min %d); using capped count at %gs interval',
                 capped, min_packets, PING_SLOW_INTERVAL_SEC)
             min_packets = capped
+        wall = int(capped * PING_SLOW_INTERVAL_SEC) + 30
         cmd = 'timeout %d ping -c %d -I %s -i %g -W 2 %s' % (
             wall, capped, bind_ip, PING_SLOW_INTERVAL_SEC, dest_ip)
         LOG.warning('Sending bound ping (slow path): %s', cmd)
@@ -506,6 +506,44 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             errors.append('%s -> 100%% packet loss' % cmd)
         detail = '; '.join(errors) if errors else 'bound ping failed'
         self.fail('Ping from %s to %s failed: %s' % (bind_ip, dest_ip, detail))
+
+    def _probe_bound_ping(self, ssh_client, bind_ip, dest_ip, count=5):
+        """Return True when at least one ICMP reply is received on bind_ip."""
+        sudo = self._guest_sudo_prefix(ssh_client)
+        base = 'ping -c %d -I %s -W 2 %s 2>&1' % (count, bind_ip, dest_ip)
+        cmd = '%s %s || true' % (sudo, base) if sudo else '%s || true' % base
+        try:
+            output = ssh_client.exec_command(cmd) or ''
+        except Exception as exc:
+            LOG.warning('Bound ping probe %s -> %s failed: %s',
+                        bind_ip, dest_ip, exc)
+            return False
+        if '100% packet loss' in output:
+            return False
+        match = re.search(r'(\d+) received', output)
+        return bool(match and int(match.group(1)) > 0)
+
+    def _flood_udp_dataplane(self, ssh_client, bind_ip, dest_ip, packet_count,
+                             broadcast=False):
+        """Send UDP datagrams bound to bind_ip (no sudo required)."""
+        bcast = 'True' if broadcast else 'False'
+        script = (
+            'import socket\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            's.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1048576)\n'
+            'if %s:\n'
+            '    s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)\n'
+            's.bind((%r, 0))\n'
+            'payload = b"x" * 1400\n'
+            'dest = (%r, 9999)\n'
+            'for _ in range(%d):\n'
+            '    try:\n'
+            '        s.sendto(payload, dest)\n'
+            '    except OSError:\n'
+            '        pass\n'
+            % (bcast, bind_ip, dest_ip, packet_count))
+        timeout_sec = max(180, int(packet_count / 500) + 60)
+        self._run_guest_python_script(ssh_client, script, timeout_sec=timeout_sec)
 
     def _assert_ovs_interface_metric_reported(self, metric_name):
         """Assert metric on openstack metric show, compute :9105, metric-storage."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -71,6 +71,16 @@ OVS_INTERFACE_ERROR_STAT_TO_METRIC = {
 }
 OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC = 'ovnc_router_port_traffic_pkts'
 OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC = 'ovnc_router_port_traffic_bytes'
+OVS_DATAPATH_FLOWS_TOTAL_METRIC = 'ovs_datapath_flows_total'
+OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC = 'ovs_datapath_lookup_hits_total'
+OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC = 'ovs_datapath_lookup_missed_total'
+OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC = 'ovs_datapath_lookup_lost_total'
+OVS_DATAPATH_METRIC_TO_DPCTL_KEY = {
+    OVS_DATAPATH_FLOWS_TOTAL_METRIC: 'flows',
+    OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC: 'hit',
+    OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC: 'missed',
+    OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC: 'lost',
+}
 NET_VF_INFO_METRIC = 'net_vf_info'
 NET_VF_RECEIVE_PACKETS_METRIC = 'net_vf_receive_packets_total'
 NET_VF_TRANSMIT_PACKETS_METRIC = 'net_vf_transmit_packets_total'
@@ -128,6 +138,9 @@ OVS_STATE_UP = 1
 OVS_STATE_DOWN = 0
 NETWORK_EXPORTER_INSTANCE_PORT = ':9105'
 FLOW_COUNT_RE = re.compile(r'flow_count=(\d+)', re.IGNORECASE)
+DPCTL_LOOKUPS_RE = re.compile(
+    r'lookups:\s*hit:(\d+)\s+missed:(\d+)\s+lost:(\d+)', re.IGNORECASE)
+DPCTL_FLOWS_RE = re.compile(r'^\s*flows:\s*(\d+)\s*$', re.MULTILINE)
 METRIC_ROW_VALUE_RE = re.compile(r'(\d+)\s*\|?\s*$')
 COMPUTE_METRICS_HOST_RE = re.compile(
     r'(\d+\.\d+\.\d+\.\d+)' + re.escape(NETWORK_EXPORTER_INSTANCE_PORT))
@@ -715,6 +728,114 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             self._router_port_label_key(sample['labels']): sample['value']
             for sample in self._router_port_samples(hypervisor_ip, metric_name)
         }
+
+    def _configured_datapath_name(self):
+        return CONF.nfv_plugin_options.network_exporter_datapath_name
+
+    def _datapath_label_key(self, labels):
+        """Stable identity for ovs_datapath_* series."""
+        return labels.get('datapath')
+
+    def _ovs_datapath_dpctl_stats(self, hypervisor_ip, datapath=None):
+        """Parse ovs-dpctl show -s for flows and lookup counters."""
+        datapath = datapath or self._configured_datapath_name()
+        cmd = 'sudo ovs-dpctl show -s 2>/dev/null'
+        output = self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
+        blocks = re.split(r'\n(?=\S)', output)
+        for block in blocks:
+            header = block.splitlines()[0] if block else ''
+            if datapath not in header:
+                continue
+            lookups = DPCTL_LOOKUPS_RE.search(block)
+            flows = DPCTL_FLOWS_RE.search(block)
+            if not lookups or not flows:
+                self.fail(
+                    'Could not parse ovs-dpctl stats for datapath %s on %s: %r'
+                    % (datapath, hypervisor_ip, block[:500]))
+            return {
+                'flows': int(flows.group(1)),
+                'hit': int(lookups.group(1)),
+                'missed': int(lookups.group(2)),
+                'lost': int(lookups.group(3)),
+            }
+        self.fail(
+            'Datapath %s not found in ovs-dpctl show on %s' % (
+                datapath, hypervisor_ip))
+
+    def _datapath_samples(self, hypervisor_ip, metric_name, datapath=None):
+        """Return datapath samples from metric-storage for one hypervisor."""
+        datapath = datapath or self._configured_datapath_name()
+        samples, error = self._metric_storage_samples(
+            metric_name, hypervisor_ip=hypervisor_ip,
+            required_labels={'datapath': datapath})
+        if samples:
+            return samples
+        LOG.warning(
+            'No %s samples in metric-storage for datapath %s on %s (%s); '
+            'trying live :9105 scrape',
+            metric_name, datapath, hypervisor_ip, error)
+        labels = {'datapath': datapath}
+        prom = self._prom_compute_metric_value(
+            hypervisor_ip, metric_name, labels)
+        if prom is not None:
+            return [{'labels': labels, 'value': prom}]
+        return self._parse_prom_samples(
+            self._scrape_compute_metrics_text(hypervisor_ip), metric_name,
+            required_labels=labels)
+
+    def _datapath_sample_map(self, hypervisor_ip, metric_name, datapath=None):
+        """Map datapath label -> value from metric-storage Prometheus."""
+        return {
+            self._datapath_label_key(sample['labels']): sample['value']
+            for sample in self._datapath_samples(
+                hypervisor_ip, metric_name, datapath=datapath)
+        }
+
+    def _datapath_metric_value(self, hypervisor_ip, metric_name, datapath=None):
+        """Return a single datapath series value for hypervisor_ip."""
+        sample_map = self._datapath_sample_map(
+            hypervisor_ip, metric_name, datapath=datapath)
+        datapath = datapath or self._configured_datapath_name()
+        if datapath in sample_map:
+            return sample_map[datapath]
+        if len(sample_map) == 1:
+            return next(iter(sample_map.values()))
+        return None
+
+    def _assert_datapath_metric_reported(self, metric_name):
+        """Assert ovs_datapath_* via metric show, :9105, and metric-storage."""
+        self._assert_ovs_interface_metric_reported(metric_name)
+        datapath = self._configured_datapath_name()
+        hypervisors = self._get_ssh_hypervisors('')
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisors available for datapath metric %s' %
+            metric_name)
+        hypervisor_ip = hypervisors[0]
+        self._assert_datapath_matches_dpctl(
+            hypervisor_ip, metric_name, datapath)
+
+    def _assert_datapath_matches_dpctl(self, hypervisor_ip, metric_name,
+                                       datapath=None):
+        """Assert exporter datapath metric matches ovs-dpctl on the hypervisor."""
+        datapath = datapath or self._configured_datapath_name()
+        dpctl_key = OVS_DATAPATH_METRIC_TO_DPCTL_KEY.get(metric_name)
+        self.assertIsNotNone(
+            dpctl_key,
+            'No dpctl mapping for datapath metric %s' % metric_name)
+        dpctl_stats = self._ovs_datapath_dpctl_stats(hypervisor_ip, datapath)
+        expected = dpctl_stats[dpctl_key]
+        reported = self._datapath_metric_value(
+            hypervisor_ip, metric_name, datapath=datapath)
+        self.assertIsNotNone(
+            reported,
+            '%s missing for datapath %s on %s' % (
+                metric_name, datapath, hypervisor_ip))
+        self.assertEqual(
+            expected, reported,
+            '%s on %s datapath %s: dpctl %s=%s exporter=%s' % (
+                metric_name, hypervisor_ip, datapath, dpctl_key, expected,
+                reported))
 
     def _assert_metric_on_compute_scrape(self, metric_name):
         """Verify metric_name is exported on at least one compute :9105 scrape."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -927,6 +927,51 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             % (datapath_type or '*', datapath, hypervisor_ip,
                found_headers, output[:800]))
 
+    def _datapath_live_samples(self, hypervisor_ip, metric_name, datapath=None,
+                               datapath_type=None):
+        """Return ovs_datapath_* samples from live :9105 on the hypervisor."""
+        if datapath is None and datapath_type is None:
+            required_labels = self._resolve_datapath_labels(
+                hypervisor_ip, metric_name)
+        else:
+            required_labels = self._datapath_required_labels(
+                datapath=datapath, datapath_type=datapath_type)
+        prom = self._prom_compute_metric_value(
+            hypervisor_ip, metric_name, required_labels)
+        if prom is not None:
+            return [{'labels': required_labels, 'value': prom}]
+        return self._parse_prom_samples(
+            self._scrape_compute_metrics_text(hypervisor_ip), metric_name,
+            required_labels=required_labels)
+
+    def _datapath_live_sample_map(self, hypervisor_ip, metric_name,
+                                  datapath=None, datapath_type=None):
+        """Map datapath name label -> value from live :9105."""
+        return {
+            self._datapath_label_key(sample['labels']): sample['value']
+            for sample in self._datapath_live_samples(
+                hypervisor_ip, metric_name, datapath=datapath,
+                datapath_type=datapath_type)
+        }
+
+    def _datapath_live_metric_value(self, hypervisor_ip, metric_name,
+                                    datapath=None, datapath_type=None):
+        """Return one ovs_datapath_* value from live :9105."""
+        if datapath is None and datapath_type is None:
+            labels = self._resolve_datapath_labels(
+                hypervisor_ip, metric_name)
+            datapath = labels['name']
+            datapath_type = labels.get('type')
+        sample_map = self._datapath_live_sample_map(
+            hypervisor_ip, metric_name, datapath=datapath,
+            datapath_type=datapath_type)
+        datapath = datapath or self._configured_datapath_name()
+        if datapath in sample_map:
+            return sample_map[datapath]
+        if len(sample_map) == 1:
+            return next(iter(sample_map.values()))
+        return None
+
     def _datapath_samples(self, hypervisor_ip, metric_name, datapath=None,
                           datapath_type=None):
         """Return datapath samples from metric-storage for one hypervisor."""
@@ -1006,7 +1051,7 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
 
     def _assert_datapath_matches_dpctl(self, hypervisor_ip, metric_name,
                                        datapath=None, datapath_type=None):
-        """Assert exporter datapath metric matches ovs-dpctl on the hypervisor."""
+        """Assert live :9105 datapath metric matches dpctl/show on hypervisor."""
         if datapath is None and datapath_type is None:
             labels = self._resolve_datapath_labels(
                 hypervisor_ip, metric_name)
@@ -1020,22 +1065,45 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         self.assertIsNotNone(
             dpctl_key,
             'No dpctl mapping for datapath metric %s' % metric_name)
-        dpctl_stats = self._ovs_datapath_dpctl_stats(
-            hypervisor_ip, datapath, datapath_type=datapath_type)
-        expected = dpctl_stats[dpctl_key]
-        reported = self._datapath_metric_value(
-            hypervisor_ip, metric_name, datapath=datapath,
-            datapath_type=datapath_type)
         datapath_label = '%s@%s' % (datapath_type or '*', datapath)
-        self.assertIsNotNone(
-            reported,
-            '%s missing for datapath %s on %s' % (
-                metric_name, datapath_label, hypervisor_ip))
-        self.assertEqual(
-            expected, reported,
-            '%s on %s datapath %s: dpctl %s=%s exporter=%s' % (
-                metric_name, hypervisor_ip, datapath_label, dpctl_key,
-                expected, reported))
+        last_exc = None
+        for attempt in range(METRIC_RETRY_ATTEMPTS):
+            dpctl_stats = self._ovs_datapath_dpctl_stats(
+                hypervisor_ip, datapath, datapath_type=datapath_type)
+            expected = dpctl_stats[dpctl_key]
+            reported = self._datapath_live_metric_value(
+                hypervisor_ip, metric_name, datapath=datapath,
+                datapath_type=datapath_type)
+            try:
+                self.assertIsNotNone(
+                    reported,
+                    '%s missing on live :9105 for datapath %s on %s' % (
+                        metric_name, datapath_label, hypervisor_ip))
+                self.assertEqual(
+                    expected, reported,
+                    '%s on %s datapath %s: dpctl %s=%s live exporter=%s' % (
+                        metric_name, hypervisor_ip, datapath_label, dpctl_key,
+                        expected, reported))
+                LOG.warning(
+                    'Datapath %s aligned with dpctl/show on %s (attempt %s): '
+                    '%s=%s',
+                    metric_name, hypervisor_ip, attempt + 1, dpctl_key,
+                    expected)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for datapath %s on %s to match '
+                    'dpctl/show: %s',
+                    attempt + 1, METRIC_RETRY_ATTEMPTS, metric_name,
+                    hypervisor_ip, exc)
+            if attempt < METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(METRIC_RETRY_INTERVAL)
+        if last_exc is not None:
+            raise last_exc
+        self.fail(
+            'Timed out waiting for datapath %s on %s to match dpctl/show' % (
+                metric_name, hypervisor_ip))
 
     def _assert_metric_on_compute_scrape(self, metric_name):
         """Verify metric_name is exported on at least one compute :9105 scrape."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -608,10 +608,11 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         detail = '; '.join(errors) if errors else 'bound ping failed'
         self.fail('Ping from %s to %s failed: %s' % (bind_ip, dest_ip, detail))
 
-    def _probe_bound_ping(self, ssh_client, bind_ip, dest_ip, count=3):
+    def _probe_bound_ping(self, ssh_client, bind_ip, dest_ip, count=8):
         """Return True when at least one ICMP reply is received on bind_ip."""
         sudo = self._guest_sudo_prefix(ssh_client)
-        base = 'ping -c %d -I %s -W 2 %s 2>&1' % (count, bind_ip, dest_ip)
+        base = (
+            'ping -c %d -I %s -i 0.2 -W 3 %s 2>&1' % (count, bind_ip, dest_ip))
         cmd = '%s %s || true' % (sudo, base) if sudo else '%s || true' % base
         try:
             output = ssh_client.exec_command(cmd) or ''

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -507,7 +507,7 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         detail = '; '.join(errors) if errors else 'bound ping failed'
         self.fail('Ping from %s to %s failed: %s' % (bind_ip, dest_ip, detail))
 
-    def _probe_bound_ping(self, ssh_client, bind_ip, dest_ip, count=5):
+    def _probe_bound_ping(self, ssh_client, bind_ip, dest_ip, count=3):
         """Return True when at least one ICMP reply is received on bind_ip."""
         sudo = self._guest_sudo_prefix(ssh_client)
         base = 'ping -c %d -I %s -W 2 %s 2>&1' % (count, bind_ip, dest_ip)

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -138,9 +138,16 @@ OVS_STATE_UP = 1
 OVS_STATE_DOWN = 0
 NETWORK_EXPORTER_INSTANCE_PORT = ':9105'
 FLOW_COUNT_RE = re.compile(r'flow_count=(\d+)', re.IGNORECASE)
-DPCTL_LOOKUPS_RE = re.compile(
-    r'lookups:\s*hit:(\d+)\s+missed:(\d+)\s+lost:(\d+)', re.IGNORECASE)
-DPCTL_FLOWS_RE = re.compile(r'^\s*flows:\s*(\d+)\s*$', re.MULTILINE)
+DPCTL_DATAPATH_HEADER_RE = re.compile(r'^([\w-]+)@([\w-]+):$')
+DPCTL_LOOKUPS_LINE_RE = re.compile(
+    r'^  lookups:\s*hit:\s*(\d+)\s+missed:\s*(\d+)\s+lost:(\d+)$')
+DPCTL_FLOWS_LINE_RE = re.compile(r'^  flows:\s*(\d+)$')
+DPCTL_SHOW_COMMANDS = (
+    'sudo ovs-appctl dpctl/show 2>/dev/null',
+    'ovs-appctl dpctl/show 2>/dev/null',
+    'sudo ovs-dpctl show -s 2>/dev/null',
+    'sudo ovs-dpctl show 2>/dev/null',
+)
 METRIC_ROW_VALUE_RE = re.compile(r'(\d+)\s*\|?\s*$')
 COMPUTE_METRICS_HOST_RE = re.compile(
     r'(\d+\.\d+\.\d+\.\d+)' + re.escape(NETWORK_EXPORTER_INSTANCE_PORT))
@@ -732,69 +739,122 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
     def _configured_datapath_name(self):
         return CONF.nfv_plugin_options.network_exporter_datapath_name
 
+    def _configured_datapath_type(self):
+        return CONF.nfv_plugin_options.network_exporter_datapath_type
+
+    def _datapath_required_labels(self, datapath=None, datapath_type=None):
+        """Prometheus labels for ovs_datapath_* (exporter uses type,name)."""
+        labels = {
+            'name': datapath or self._configured_datapath_name(),
+        }
+        dtype = (datapath_type if datapath_type is not None
+                 else self._configured_datapath_type())
+        if dtype:
+            labels['type'] = dtype
+        return labels
+
     def _datapath_label_key(self, labels):
         """Stable identity for ovs_datapath_* series."""
-        return labels.get('datapath')
+        return labels.get('name') or labels.get('datapath')
 
-    def _ovs_datapath_dpctl_stats(self, hypervisor_ip, datapath=None):
-        """Parse ovs-dpctl show -s for flows and lookup counters."""
-        datapath = datapath or self._configured_datapath_name()
-        cmd = 'sudo ovs-dpctl show -s 2>/dev/null'
-        output = self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
-        blocks = re.split(r'\n(?=\S)', output)
-        for block in blocks:
-            header = block.splitlines()[0] if block else ''
-            if datapath not in header:
-                continue
-            lookups = DPCTL_LOOKUPS_RE.search(block)
-            flows = DPCTL_FLOWS_RE.search(block)
-            if not lookups or not flows:
-                self.fail(
-                    'Could not parse ovs-dpctl stats for datapath %s on %s: %r'
-                    % (datapath, hypervisor_ip, block[:500]))
-            return {
-                'flows': int(flows.group(1)),
-                'hit': int(lookups.group(1)),
-                'missed': int(lookups.group(2)),
-                'lost': int(lookups.group(3)),
-            }
+    def _ovs_datapath_dpctl_show_output(self, hypervisor_ip):
+        """Fetch dpctl/show text (same source as openstack-network-exporter)."""
+        last_output = ''
+        for cmd in DPCTL_SHOW_COMMANDS:
+            output = self._ssh_run_on_hypervisor(
+                hypervisor_ip, cmd, check_rc=False)
+            if output and output.strip():
+                return output
+            last_output = output or last_output
         self.fail(
-            'Datapath %s not found in ovs-dpctl show on %s' % (
-                datapath, hypervisor_ip))
+            'Could not get dpctl/show output on %s (last output: %r)' % (
+                hypervisor_ip, (last_output or '')[:500]))
 
-    def _datapath_samples(self, hypervisor_ip, metric_name, datapath=None):
-        """Return datapath samples from metric-storage for one hypervisor."""
+    def _ovs_datapath_dpctl_stats(self, hypervisor_ip, datapath=None,
+                                  datapath_type=None):
+        """Parse ovs-appctl dpctl/show for flows and lookup counters."""
         datapath = datapath or self._configured_datapath_name()
+        datapath_type = (datapath_type if datapath_type is not None
+                         else self._configured_datapath_type())
+        output = self._ovs_datapath_dpctl_show_output(hypervisor_ip)
+        current_type = ''
+        current_name = ''
+        found_headers = []
+        target_stats = None
+
+        for line in output.splitlines():
+            header = DPCTL_DATAPATH_HEADER_RE.match(line)
+            if header:
+                current_type, current_name = header.group(1), header.group(2)
+                found_headers.append('%s@%s' % (current_type, current_name))
+                continue
+
+            if current_name != datapath:
+                continue
+            if datapath_type and current_type != datapath_type:
+                continue
+
+            if target_stats is None:
+                target_stats = {}
+
+            lookups = DPCTL_LOOKUPS_LINE_RE.match(line)
+            if lookups:
+                target_stats.update(
+                    hit=int(lookups.group(1)),
+                    missed=int(lookups.group(2)),
+                    lost=int(lookups.group(3)))
+                continue
+            flows = DPCTL_FLOWS_LINE_RE.match(line)
+            if flows:
+                target_stats['flows'] = int(flows.group(1))
+
+        if (target_stats and 'flows' in target_stats and
+                'hit' in target_stats):
+            return target_stats
+
+        self.fail(
+            'Datapath %s@%s not found in dpctl/show on %s (seen %s; output: %r)'
+            % (datapath_type or '*', datapath, hypervisor_ip,
+               found_headers, output[:800]))
+
+    def _datapath_samples(self, hypervisor_ip, metric_name, datapath=None,
+                          datapath_type=None):
+        """Return datapath samples from metric-storage for one hypervisor."""
+        required_labels = self._datapath_required_labels(
+            datapath=datapath, datapath_type=datapath_type)
         samples, error = self._metric_storage_samples(
             metric_name, hypervisor_ip=hypervisor_ip,
-            required_labels={'datapath': datapath})
+            required_labels=required_labels)
         if samples:
             return samples
         LOG.warning(
             'No %s samples in metric-storage for datapath %s on %s (%s); '
             'trying live :9105 scrape',
-            metric_name, datapath, hypervisor_ip, error)
-        labels = {'datapath': datapath}
+            metric_name, required_labels, hypervisor_ip, error)
         prom = self._prom_compute_metric_value(
-            hypervisor_ip, metric_name, labels)
+            hypervisor_ip, metric_name, required_labels)
         if prom is not None:
-            return [{'labels': labels, 'value': prom}]
+            return [{'labels': required_labels, 'value': prom}]
         return self._parse_prom_samples(
             self._scrape_compute_metrics_text(hypervisor_ip), metric_name,
-            required_labels=labels)
+            required_labels=required_labels)
 
-    def _datapath_sample_map(self, hypervisor_ip, metric_name, datapath=None):
-        """Map datapath label -> value from metric-storage Prometheus."""
+    def _datapath_sample_map(self, hypervisor_ip, metric_name, datapath=None,
+                             datapath_type=None):
+        """Map datapath name label -> value from metric-storage Prometheus."""
         return {
             self._datapath_label_key(sample['labels']): sample['value']
             for sample in self._datapath_samples(
-                hypervisor_ip, metric_name, datapath=datapath)
+                hypervisor_ip, metric_name, datapath=datapath,
+                datapath_type=datapath_type)
         }
 
-    def _datapath_metric_value(self, hypervisor_ip, metric_name, datapath=None):
+    def _datapath_metric_value(self, hypervisor_ip, metric_name, datapath=None,
+                               datapath_type=None):
         """Return a single datapath series value for hypervisor_ip."""
         sample_map = self._datapath_sample_map(
-            hypervisor_ip, metric_name, datapath=datapath)
+            hypervisor_ip, metric_name, datapath=datapath,
+            datapath_type=datapath_type)
         datapath = datapath or self._configured_datapath_name()
         if datapath in sample_map:
             return sample_map[datapath]
@@ -811,9 +871,20 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             hypervisors,
             'No compute hypervisors available for datapath metric %s' %
             metric_name)
-        hypervisor_ip = hypervisors[0]
-        self._assert_datapath_matches_dpctl(
-            hypervisor_ip, metric_name, datapath)
+        last_exc = None
+        for hypervisor_ip in hypervisors:
+            try:
+                self._assert_datapath_matches_dpctl(
+                    hypervisor_ip, metric_name, datapath)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Datapath dpctl check failed on %s for %s: %s',
+                    hypervisor_ip, metric_name, exc)
+        self.fail(
+            'Datapath metric %s did not match dpctl/show on any hypervisor '
+            '%s; last error: %s' % (metric_name, hypervisors, last_exc))
 
     def _assert_datapath_matches_dpctl(self, hypervisor_ip, metric_name,
                                        datapath=None):

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -71,6 +71,41 @@ OVS_INTERFACE_ERROR_STAT_TO_METRIC = {
 }
 OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC = 'ovnc_router_port_traffic_pkts'
 OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC = 'ovnc_router_port_traffic_bytes'
+OVNC_ENCAP_IP_METRIC = 'ovnc_encap_ip'
+OVNC_ENCAP_TYPE_METRIC = 'ovnc_encap_type'
+OVNC_SB_CONNECTION_METHOD_METRIC = 'ovnc_sb_connection_method'
+OVNC_MONITOR_ALL_METRIC = 'ovnc_monitor_all'
+OVNC_BRIDGE_MAPPINGS_METRIC = 'ovnc_bridge_mappings'
+OVNC_CONFIG_METRICS = (
+    OVNC_ENCAP_IP_METRIC,
+    OVNC_ENCAP_TYPE_METRIC,
+    OVNC_SB_CONNECTION_METHOD_METRIC,
+    OVNC_MONITOR_ALL_METRIC,
+    OVNC_BRIDGE_MAPPINGS_METRIC,
+)
+OVNC_TXN_SUCCESS_METRIC = 'ovnc_txn_success'
+OVNC_TXN_UNCOMMITTED_METRIC = 'ovnc_txn_uncommitted'
+OVNC_TXN_ABORTED_METRIC = 'ovnc_txn_aborted'
+OVNC_TXN_ERROR_METRIC = 'ovnc_txn_error'
+OVNC_TXN_METRICS = (
+    OVNC_TXN_SUCCESS_METRIC,
+    OVNC_TXN_UNCOMMITTED_METRIC,
+    OVNC_TXN_ABORTED_METRIC,
+    OVNC_TXN_ERROR_METRIC,
+)
+OVNC_METRIC_TO_EXTERNAL_ID = {
+    OVNC_ENCAP_IP_METRIC: ('ovn-encap-ip', 'encap_ip'),
+    OVNC_ENCAP_TYPE_METRIC: ('ovn-encap-type', 'encap_type'),
+    OVNC_SB_CONNECTION_METHOD_METRIC: ('ovn-remote', 'sb_connection_method'),
+    OVNC_MONITOR_ALL_METRIC: ('ovn-monitor-all', None),
+    OVNC_BRIDGE_MAPPINGS_METRIC: ('ovn-bridge-mappings', None),
+}
+OVNC_TXN_METRIC_TO_COVERAGE_KEY = {
+    OVNC_TXN_SUCCESS_METRIC: 'txn_success',
+    OVNC_TXN_UNCOMMITTED_METRIC: 'txn_uncommitted',
+    OVNC_TXN_ABORTED_METRIC: 'txn_aborted',
+    OVNC_TXN_ERROR_METRIC: 'txn_error',
+}
 OVS_DATAPATH_FLOWS_TOTAL_METRIC = 'ovs_datapath_flows_total'
 OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC = 'ovs_datapath_lookup_hits_total'
 OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC = 'ovs_datapath_lookup_missed_total'
@@ -211,6 +246,14 @@ MEMORY_SHOW_COMMANDS = (
     'sudo ovs-appctl memory/show 2>/dev/null',
     'ovs-appctl memory/show 2>/dev/null',
 )
+OVN_COVERAGE_TOTAL_RE = re.compile(
+    r'^(\w+)\s+.*\s+total:\s*(\d+)\s*$')
+OVN_COVERAGE_METRICS_DELIMITER = '---OVN_COVERAGE_METRICS---'
+OVN_COVERAGE_SHOW_COMMANDS = (
+    'sudo ovs-appctl -t ovn-controller coverage/show 2>/dev/null',
+    'ovs-appctl -t ovn-controller coverage/show 2>/dev/null',
+)
+OVS_EXTERNAL_ID_RE = re.compile(r'([\w-]+)="([^"]*)"')
 PMD_RXQ_OVERHEAD_RE = re.compile(r'^\s*overhead\s*:\s*([\d.]+)\s*%$')
 PMD_RXQ_USAGE_RE = re.compile(
     r'^\s*port:\s*(\S+)\s+queue-id:\s*(\d+)\s+\((enabled|disabled)\)\s+'
@@ -761,6 +804,10 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
 
     def _assert_router_port_metric_reported(self, metric_name):
         """Assert ovnc_router_port_traffic_* via openstack metric show and storage."""
+        self._assert_ovn_controller_metric_reported(metric_name)
+
+    def _assert_ovn_controller_metric_reported(self, metric_name):
+        """Assert OVN :1981 metrics via metric show, storage, and live scrape."""
         self._assert_metric_reported(metric_name)
         storage_samples, query_error = self._metric_storage_samples(metric_name)
         self.assertNotEmpty(
@@ -770,7 +817,7 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         if not self._metric_on_ovn_scrape(metric_name):
             LOG.warning(
                 '%s present in metric-storage but not on a Tempest-reachable '
-                'OVN :1981 scrape; router port tests use metric-storage',
+                'OVN :1981 scrape',
                 metric_name)
 
     def _router_port_label_key(self, labels):
@@ -1692,6 +1739,350 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             'Memory metric %s did not match memory/show on any hypervisor '
             '%s; last error: %s' % (
                 metric_name, memory_hypervisors, last_exc))
+
+    def _ovs_open_vswitch_external_ids(self, hypervisor_ip):
+        """Parse Open_vSwitch external_ids from ovs-vsctl on a compute node."""
+        last_output = ''
+        for cmd in (
+                'sudo ovs-vsctl get Open_vSwitch . external_ids 2>/dev/null',
+                'ovs-vsctl get Open_vSwitch . external_ids 2>/dev/null'):
+            output = self._ssh_run_on_hypervisor(
+                hypervisor_ip, cmd, check_rc=False)
+            if output and output.strip():
+                return dict(OVS_EXTERNAL_ID_RE.findall(output))
+            last_output = output or last_output
+        self.fail(
+            'Could not get Open_vSwitch external_ids on %s (last output: %r)' % (
+                hypervisor_ip, (last_output or '')[:500]))
+
+    def _ovnc_bridge_mappings_pairs(self, external_ids):
+        """Return (network, bridge) pairs from ovn-bridge-mappings external_id."""
+        mappings = external_ids.get('ovn-bridge-mappings', '')
+        if not mappings:
+            return []
+        pairs = []
+        for item in mappings.split(','):
+            item = item.strip()
+            if not item or ':' not in item:
+                continue
+            network, bridge = item.split(':', 1)
+            pairs.append((network.strip(), bridge.strip()))
+        return pairs
+
+    def _ovn_coverage_show_output(self, hypervisor_ip):
+        """Fetch ovn-controller coverage/show text (exporter ground truth)."""
+        last_output = ''
+        for cmd in OVN_COVERAGE_SHOW_COMMANDS:
+            output = self._ssh_run_on_hypervisor(
+                hypervisor_ip, cmd, check_rc=False)
+            if output and output.strip():
+                return output
+            last_output = output or last_output
+        self.fail(
+            'Could not get ovn-controller coverage/show on %s (last output: %r)'
+            % (hypervisor_ip, (last_output or '')[:500]))
+
+    def _ovn_coverage_totals(self, hypervisor_ip, output=None):
+        """Parse coverage/show totals for known ovnc_txn_* keys only."""
+        if output is None:
+            output = self._ovn_coverage_show_output(hypervisor_ip)
+        known_keys = set(OVNC_TXN_METRIC_TO_COVERAGE_KEY.values())
+        totals = {}
+        for line in (output or '').splitlines():
+            match = OVN_COVERAGE_TOTAL_RE.match(line.strip())
+            if not match:
+                continue
+            key = match.group(1)
+            if key in known_keys:
+                totals[key] = int(match.group(2))
+        return totals
+
+    def _ovnc_live_samples(self, hypervisor_ip, metric_name,
+                           metrics_output=None):
+        """Parse labeled/unlabeled OVN :1981 samples for one metric."""
+        if metrics_output is not None:
+            return self._parse_prom_samples(metrics_output, metric_name)
+        samples = []
+        for _source, output in self._ovn_metric_scrape_outputs(hypervisor_ip):
+            samples.extend(self._parse_prom_samples(output, metric_name))
+        return samples
+
+    def _ovnc_live_metric_value(self, hypervisor_ip, metric_name,
+                                metrics_output=None):
+        """Return peak live :1981 value for an unlabeled ovnc_txn_* counter."""
+        samples = self._ovnc_live_samples(
+            hypervisor_ip, metric_name, metrics_output=metrics_output)
+        if not samples:
+            return 0
+        return max(sample['value'] for sample in samples)
+
+    def _ovn_coverage_and_live_output(self, hypervisor_ip):
+        """Fetch coverage/show and :1981 metrics in one SSH round-trip."""
+        cmd = (
+            "COVERAGE=$(sudo ovs-appctl -t ovn-controller coverage/show "
+            "2>/dev/null || ovs-appctl -t ovn-controller coverage/show "
+            "2>/dev/null); "
+            "printf '%%s\\n%s\\n' \"$COVERAGE\" '%s'; "
+            "curl -sk https://127.0.0.1:1981/metrics 2>/dev/null || "
+            "curl -s http://127.0.0.1:1981/metrics 2>/dev/null"
+            % (OVN_COVERAGE_METRICS_DELIMITER,
+               OVN_COVERAGE_METRICS_DELIMITER))
+        return self._ssh_run_on_hypervisor(hypervisor_ip, cmd, check_rc=False)
+
+    def _split_ovn_coverage_and_metrics(self, combined_output):
+        """Split combined SSH output into coverage/show text and :1981 scrape."""
+        if OVN_COVERAGE_METRICS_DELIMITER in (combined_output or ''):
+            coverage_output, metrics_output = combined_output.split(
+                OVN_COVERAGE_METRICS_DELIMITER, 1)
+            return coverage_output.strip(), metrics_output.strip()
+        return (combined_output or '').strip(), ''
+
+    def _hypervisors_with_ovn_controller(self, hypervisors):
+        """Return hypervisors with OVN controller config or coverage/show."""
+        found = []
+        for hypervisor_ip in hypervisors:
+            try:
+                for cmd in (
+                        'sudo ovs-vsctl get Open_vSwitch . external_ids '
+                        '2>/dev/null',
+                        'ovs-vsctl get Open_vSwitch . external_ids '
+                        '2>/dev/null'):
+                    output = self._ssh_run_on_hypervisor(
+                        hypervisor_ip, cmd, check_rc=False)
+                    if output.strip():
+                        ext_ids = dict(OVS_EXTERNAL_ID_RE.findall(output))
+                        if ext_ids.get('ovn-remote'):
+                            found.append(hypervisor_ip)
+                            break
+                else:
+                    for cmd in OVN_COVERAGE_SHOW_COMMANDS:
+                        output = self._ssh_run_on_hypervisor(
+                            hypervisor_ip, cmd, check_rc=False)
+                        if output and output.strip():
+                            found.append(hypervisor_ip)
+                            break
+            except Exception as exc:
+                LOG.warning(
+                    'No OVN controller on %s: %s', hypervisor_ip, exc)
+        return found
+
+    def _expected_ovnc_monitor_all(self, external_ids):
+        """Map ovn-monitor-all external_id to exporter gauge 0/1."""
+        value = external_ids.get('ovn-monitor-all', '')
+        return 1 if value.lower() == 'true' else 0
+
+    def _assert_ovnc_config_matches_external_ids(
+            self, hypervisor_ip, metric_name):
+        """Assert live :1981 ovnc_* config metrics match ovs-vsctl external_ids."""
+        mapping = OVNC_METRIC_TO_EXTERNAL_ID.get(metric_name)
+        self.assertIsNotNone(
+            mapping, 'No external_ids mapping for metric %s' % metric_name)
+        ext_id_key, label_key = mapping
+        external_ids = self._ovs_open_vswitch_external_ids(hypervisor_ip)
+        live_samples = self._ovnc_live_samples(hypervisor_ip, metric_name)
+        self.assertNotEmpty(
+            live_samples,
+            '%s missing on live OVN :1981 on %s' % (
+                metric_name, hypervisor_ip))
+
+        if metric_name == OVNC_MONITOR_ALL_METRIC:
+            expected = self._expected_ovnc_monitor_all(external_ids)
+            unlabeled = [
+                sample['value'] for sample in live_samples
+                if not sample['labels']]
+            self.assertNotEmpty(
+                unlabeled,
+                '%s has no unlabeled live samples on %s' % (
+                    metric_name, hypervisor_ip))
+            reported = unlabeled[0]
+            self.assertEqual(
+                expected, reported,
+                '%s on %s: external_ids %s=%s live=%s' % (
+                    metric_name, hypervisor_ip, ext_id_key,
+                    external_ids.get(ext_id_key), reported))
+            return
+
+        if metric_name == OVNC_BRIDGE_MAPPINGS_METRIC:
+            pairs = self._ovnc_bridge_mappings_pairs(external_ids)
+            self.assertNotEmpty(
+                pairs,
+                'ovn-bridge-mappings missing on %s for %s' % (
+                    hypervisor_ip, metric_name))
+            live_map = {
+                (sample['labels'].get('network'),
+                 sample['labels'].get('bridge')): sample['value']
+                for sample in live_samples
+            }
+            for network, bridge in pairs:
+                reported = live_map.get((network, bridge))
+                self.assertIsNotNone(
+                    reported,
+                    '%s missing network=%s bridge=%s on %s (live labels %s)' % (
+                        metric_name, network, bridge, hypervisor_ip,
+                        sorted(live_map.keys())))
+                self.assertEqual(
+                    1, reported,
+                    '%s on %s network=%s bridge=%s: expected 1 live=%s' % (
+                        metric_name, hypervisor_ip, network, bridge,
+                        reported))
+            return
+
+        expected_value = external_ids.get(ext_id_key)
+        self.assertIsNotNone(
+            expected_value,
+            '%s missing from external_ids on %s' % (
+                ext_id_key, hypervisor_ip))
+        matching = [
+            sample for sample in live_samples
+            if sample['labels'].get(label_key) == expected_value]
+        self.assertNotEmpty(
+            matching,
+            '%s on %s: no live sample with %s=%r (external_ids); live %s' % (
+                metric_name, hypervisor_ip, label_key, expected_value,
+                [sample['labels'] for sample in live_samples]))
+        for sample in matching:
+            self.assertEqual(
+                1, sample['value'],
+                '%s on %s %s=%s: expected gauge 1 live=%s' % (
+                    metric_name, hypervisor_ip, label_key, expected_value,
+                    sample['value']))
+
+    def _assert_ovnc_config_metric_reported(self, metric_name):
+        """Assert ovnc_* config via metric show, storage, and external_ids."""
+        self._assert_ovn_controller_metric_reported(metric_name)
+        hypervisors = self._get_ssh_hypervisors('')
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisors available for OVN config metric %s' % (
+                metric_name))
+        ovn_hypervisors = self._hypervisors_with_ovn_controller(hypervisors)
+        self.assertNotEmpty(
+            ovn_hypervisors,
+            'No OVN controller on hypervisors %s for %s' % (
+                hypervisors, metric_name))
+        if metric_name == OVNC_BRIDGE_MAPPINGS_METRIC:
+            ovn_hypervisors = [
+                hypervisor_ip for hypervisor_ip in ovn_hypervisors
+                if self._ovnc_bridge_mappings_pairs(
+                    self._ovs_open_vswitch_external_ids(hypervisor_ip))]
+            self.assertNotEmpty(
+                ovn_hypervisors,
+                'No ovn-bridge-mappings on hypervisors for %s' % metric_name)
+        last_exc = None
+        for hypervisor_ip in ovn_hypervisors:
+            try:
+                self._assert_ovnc_config_matches_external_ids(
+                    hypervisor_ip, metric_name)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'OVN config check failed on %s for %s: %s',
+                    hypervisor_ip, metric_name, exc)
+        self.fail(
+            'OVN config metric %s did not match external_ids on any '
+            'hypervisor %s; last error: %s' % (
+                metric_name, ovn_hypervisors, last_exc))
+
+    def _assert_ovnc_txn_matches_coverage(self, hypervisor_ip, metric_name):
+        """Assert live :1981 ovnc_txn_* equals coverage/show on hypervisor."""
+        coverage_key = OVNC_TXN_METRIC_TO_COVERAGE_KEY.get(metric_name)
+        self.assertIsNotNone(
+            coverage_key,
+            'No coverage/show mapping for metric %s' % metric_name)
+        last_exc = None
+        for attempt in range(METRIC_RETRY_ATTEMPTS):
+            combined = self._ovn_coverage_and_live_output(hypervisor_ip)
+            coverage_output, metrics_output = (
+                self._split_ovn_coverage_and_metrics(combined))
+            if not coverage_output:
+                coverage_output = self._ovn_coverage_show_output(hypervisor_ip)
+            if not metrics_output:
+                for _source, output in self._ovn_metric_scrape_outputs(
+                        hypervisor_ip):
+                    if output.strip():
+                        metrics_output = output
+                        break
+            totals = self._ovn_coverage_totals(
+                hypervisor_ip, output=coverage_output)
+            expected = totals.get(coverage_key, 0)
+            reported = self._ovnc_live_metric_value(
+                hypervisor_ip, metric_name, metrics_output=metrics_output)
+            try:
+                self.assertEqual(
+                    expected, reported,
+                    '%s on %s: coverage/show %s=%s live=%s' % (
+                        metric_name, hypervisor_ip, coverage_key,
+                        expected, reported))
+                LOG.warning(
+                    'OVN txn %s aligned with coverage/show on %s (attempt %s): '
+                    'show=%s live=%s',
+                    metric_name, hypervisor_ip, attempt + 1,
+                    expected, reported)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for OVN txn %s on %s: %s',
+                    attempt + 1, METRIC_RETRY_ATTEMPTS, metric_name,
+                    hypervisor_ip, exc)
+            if attempt < METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(METRIC_RETRY_INTERVAL)
+        if last_exc is not None:
+            raise last_exc
+        self.fail(
+            'Timed out waiting for OVN txn %s on %s to match coverage/show' % (
+                metric_name, hypervisor_ip))
+
+    def _assert_ovnc_txn_metric_reported(self, metric_name):
+        """Assert ovnc_txn_* via metric show, storage, and coverage/show."""
+        self._assert_ovn_controller_metric_reported(metric_name)
+        hypervisors = self._get_ssh_hypervisors('')
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisors available for OVN txn metric %s' % (
+                metric_name))
+        ovn_hypervisors = self._hypervisors_with_ovn_controller(hypervisors)
+        self.assertNotEmpty(
+            ovn_hypervisors,
+            'No OVN controller on hypervisors %s for %s' % (
+                hypervisors, metric_name))
+        last_exc = None
+        for hypervisor_ip in ovn_hypervisors:
+            try:
+                self._assert_ovnc_txn_matches_coverage(
+                    hypervisor_ip, metric_name)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'OVN txn check failed on %s for %s: %s',
+                    hypervisor_ip, metric_name, exc)
+        self.fail(
+            'OVN txn metric %s did not match coverage/show on any hypervisor '
+            '%s; last error: %s' % (
+                metric_name, ovn_hypervisors, last_exc))
+
+    def _ovnc_txn_success_totals(self, hypervisor_ip):
+        """Return (coverage/show total, live :1981 value) for txn_success."""
+        combined = self._ovn_coverage_and_live_output(hypervisor_ip)
+        coverage_output, metrics_output = (
+            self._split_ovn_coverage_and_metrics(combined))
+        if not coverage_output:
+            coverage_output = self._ovn_coverage_show_output(hypervisor_ip)
+        if not metrics_output:
+            for _source, output in self._ovn_metric_scrape_outputs(
+                    hypervisor_ip):
+                if output.strip():
+                    metrics_output = output
+                    break
+        totals = self._ovn_coverage_totals(
+            hypervisor_ip, output=coverage_output)
+        show_total = totals.get('txn_success', 0)
+        live_total = self._ovnc_live_metric_value(
+            hypervisor_ip, OVNC_TXN_SUCCESS_METRIC,
+            metrics_output=metrics_output)
+        return show_total, live_total
 
     def _max_rxq_usage_percent(self, hypervisor_ip, output=None):
         """Return peak RxQ usage percent from pmd-rxq-show and live :9105."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -110,6 +110,11 @@ NET_VF_METRIC_TO_SYSFS_STAT = {
 }
 # OVN/K8s service metrics (northd, controller, etc.), not compute :9105
 OVN_K8S_METRICS_PORT = ':1981'
+OVN_CONTROLLER_METRICS_POD_RE = r'ovn-controller-metrics.*'
+OVN_CONTROLLER_METRICS_CONTAINER = 'ovn-controller-metrics'
+OVN_CONTROLLER_METRICS_CURL = (
+    'curl -sk https://127.0.0.1:1981/metrics 2>/dev/null || '
+    'curl -s http://127.0.0.1:1981/metrics 2>/dev/null')
 PROM_METRIC_LINE_RE = re.compile(
     r'^(?P<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)'
     r'\{(?P<labels>[^}]*)\}\s+'
@@ -288,6 +293,89 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         cmd_http = "curl -s http://127.0.0.1:9105/metrics 2>/dev/null"
         return self._ssh_run_on_hypervisor(hypervisor_ip, cmd_http)
 
+    def _scrape_ovn_metrics_text(self, hypervisor_ip):
+        """Return OVN controller exporter Prometheus text from a compute node."""
+        return self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip, OVN_CONTROLLER_METRICS_CURL)
+
+    def _ovn_controller_metrics_pods(self):
+        return self.k8s_client.search_pods_using_regex(
+            OVN_CONTROLLER_METRICS_POD_RE, OPENSTACK_NAMESPACE)
+
+    def _ovn_controller_metrics_pod_on_hypervisor(self, hypervisor_ip):
+        for pod in self._ovn_controller_metrics_pods():
+            node = (pod.get('spec') or {}).get('nodeName') or ''
+            if not node:
+                continue
+            node_short = node.split('.')[0]
+            for ident in self._hypervisor_identifiers(hypervisor_ip):
+                ident_short = ident.split('.')[0]
+                if (ident in node or node in ident or
+                        ident_short == node_short):
+                    return pod['metadata']['name']
+        return None
+
+    def _scrape_ovn_controller_metrics_pod(self, hypervisor_ip=None):
+        """Scrape ovn-controller-metrics :1981 via pod exec."""
+        pod_name = None
+        if hypervisor_ip:
+            pod_name = self._ovn_controller_metrics_pod_on_hypervisor(
+                hypervisor_ip)
+        if not pod_name:
+            pods = self._ovn_controller_metrics_pods()
+            if pods:
+                pod_name = pods[0]['metadata']['name']
+        if not pod_name:
+            return ''
+        try:
+            return self.k8s_client.execute_command_in_pod(
+                pod_name, OPENSTACK_NAMESPACE,
+                OVN_CONTROLLER_METRICS_CONTAINER,
+                OVN_CONTROLLER_METRICS_CURL)
+        except Exception as exc:
+            LOG.warning(
+                'ovn-controller-metrics scrape failed for pod %s: %s',
+                pod_name, exc)
+            return ''
+
+    def _ovn_metric_scrape_outputs(self, hypervisor_ip=None):
+        """Yield Prometheus text from OVN :1981 sources (node-local then pod)."""
+        if hypervisor_ip:
+            output = self._scrape_ovn_metrics_text(hypervisor_ip)
+            if output.strip():
+                yield ('compute:%s' % hypervisor_ip, output)
+        pod_output = self._scrape_ovn_controller_metrics_pod(hypervisor_ip)
+        if pod_output.strip():
+            yield ('ovn-controller-metrics', pod_output)
+
+    def _assert_metric_on_ovn_scrape(self, metric_name):
+        """Verify metric_name appears on an OVN :1981 scrape target."""
+        hypervisors = self._get_hypervisor_ip_from_undercloud()
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisor IPs available for OVN :1981 scrape')
+        found_on = []
+        for hypervisor_ip in hypervisors:
+            for source, output in self._ovn_metric_scrape_outputs(hypervisor_ip):
+                for line in output.splitlines():
+                    stripped = line.strip()
+                    if stripped.startswith(metric_name + '{') or stripped.startswith(
+                            metric_name + ' '):
+                        found_on.append('%s@%s' % (source, hypervisor_ip))
+                        break
+                if found_on:
+                    break
+            if found_on:
+                break
+        self.assertNotEmpty(
+            found_on,
+            "Metric '%s' not found on OVN :1981 scrape from hypervisors %s "
+            "(checked local :1981 and ovn-controller-metrics pods)" % (
+                metric_name, hypervisors))
+        LOG.warning(
+            "Metric '%s' found on OVN :1981 scrape from %s",
+            metric_name, found_on)
+
     def _guest_has_passwordless_sudo(self, ssh_client):
         """Return True when the guest accepts ``sudo -n`` without prompting."""
         try:
@@ -436,8 +524,9 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 metric_name, query_error))
 
     def _assert_router_port_metric_reported(self, metric_name):
-        """Assert ovnc_router_port_traffic_* on compute :9105 and metric-storage."""
-        self._assert_metric_on_compute_scrape(metric_name)
+        """Assert ovnc_router_port_traffic_* on OVN :1981 and metric-storage."""
+        self._assert_metric_reported(metric_name)
+        self._assert_metric_on_ovn_scrape(metric_name)
         storage_samples, query_error = self._metric_storage_samples(metric_name)
         self.assertNotEmpty(
             storage_samples,
@@ -448,18 +537,25 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         """Stable identity for ovnc_router_port_traffic series."""
         return (labels.get('datapath'), labels.get('port'))
 
+    def _router_port_prom_samples(self, hypervisor_ip, metric_name):
+        """Return router-port samples from OVN :1981 (not compute :9105)."""
+        for _source, output in self._ovn_metric_scrape_outputs(hypervisor_ip):
+            samples = self._parse_prom_samples(output, metric_name)
+            if samples:
+                return samples
+        return self._parse_prom_samples(
+            self._scrape_compute_metrics_text(hypervisor_ip), metric_name)
+
     def _prom_router_port_samples(self, hypervisor_ip, metric_name):
-        """Return all router-port metric samples from compute :9105."""
-        output = self._scrape_compute_metrics_text(hypervisor_ip)
-        return self._parse_prom_samples(output, metric_name)
+        """Return all router-port metric samples from OVN :1981."""
+        return self._router_port_prom_samples(hypervisor_ip, metric_name)
 
     def _router_port_sample_map(self, hypervisor_ip, metric_name, storage=False):
-        """Map (datapath, port) -> value from :9105 or metric-storage."""
+        """Map (datapath, port) -> value from OVN :1981 or metric-storage."""
         if storage:
-            samples, _ = self._metric_storage_samples(
-                metric_name, hypervisor_ip=hypervisor_ip)
+            samples, _ = self._metric_storage_samples(metric_name)
         else:
-            samples = self._prom_router_port_samples(hypervisor_ip, metric_name)
+            samples = self._router_port_prom_samples(hypervisor_ip, metric_name)
         return {
             self._router_port_label_key(sample['labels']): sample['value']
             for sample in samples

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -1214,11 +1214,13 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             metrics_output = self._scrape_compute_metrics_text(hypervisor_ip)
         return self._parse_prom_samples(metrics_output, metric_name)
 
-    def _pmd_live_total(self, hypervisor_ip, metric_name):
+    def _pmd_live_total(self, hypervisor_ip, metric_name,
+                        metrics_output=None):
         """Sum ovs_pmd_* across all PMD threads on one hypervisor."""
         return sum(
             sample['value']
-            for sample in self._pmd_live_samples(hypervisor_ip, metric_name))
+            for sample in self._pmd_live_samples(
+                hypervisor_ip, metric_name, metrics_output=metrics_output))
 
     def _pmd_perf_total(self, hypervisor_ip, metric_name):
         """Sum one pmd-perf-show stat across all PMD threads."""
@@ -1527,6 +1529,35 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         values = list(rxq_usage.values())
         values.extend(sample['value'] for sample in live_samples)
         return max(values) if values else 0.0
+
+    def _pmd_min_packet_threshold(self):
+        configured = CONF.nfv_plugin_options.network_exporter_pmd_min_packets
+        if configured:
+            return configured
+        count = CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _pmd_perf_activity_totals(self, hypervisor_ip):
+        """Summed PMD perf counters used as traffic-activity fallback."""
+        return {
+            'busy': self._pmd_perf_total(
+                hypervisor_ip, OVS_PMD_BUSY_ITERATIONS_METRIC),
+            'rx': self._pmd_perf_total(
+                hypervisor_ip, OVS_PMD_RX_PACKETS_METRIC),
+        }
+
+    def _pmd_live_activity_totals(self, hypervisor_ip, metrics_output=None):
+        """Summed live :9105 PMD counters for traffic-activity fallback."""
+        return {
+            'busy': self._pmd_live_total(
+                hypervisor_ip, OVS_PMD_BUSY_ITERATIONS_METRIC,
+                metrics_output=metrics_output),
+            'rx': self._pmd_live_total(
+                hypervisor_ip, OVS_PMD_RX_PACKETS_METRIC,
+                metrics_output=metrics_output),
+        }
 
     def _assert_metric_on_compute_scrape(self, metric_name):
         """Verify metric_name is exported on at least one compute :9105 scrape."""

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -1568,13 +1568,20 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 stats[key] = int(match.group(2))
         return stats
 
+    def _memory_show_expected_value(self, stats, show_key):
+        """Return memory/show count; OVS omits zero-valued keys from output."""
+        return stats.get(show_key, 0)
+
     def _memory_live_metric_value(self, hypervisor_ip, metric_name,
                                   metrics_output=None):
         """Read one unlabeled ovs_memory_* gauge from a :9105 scrape."""
         if metrics_output is None:
             metrics_output = self._scrape_compute_metrics_text(hypervisor_ip)
-        return self._parse_prom_metric_text(
+        value = self._parse_prom_metric_text(
             metrics_output, metric_name, {})
+        if value is None:
+            return 0
+        return value
 
     def _memory_show_and_live_output(self, hypervisor_ip):
         """Fetch memory/show and :9105 metrics in one SSH round-trip."""
@@ -1595,17 +1602,17 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             return show_output.strip(), metrics_output.strip()
         return (combined_output or '').strip(), ''
 
-    def _hypervisors_with_memory_show(self, hypervisors, show_key=None):
-        """Return hypervisors that export memory/show stats."""
+    def _hypervisors_with_memory_show(self, hypervisors):
+        """Return hypervisors that respond to ovs-appctl memory/show."""
         found = []
         for hypervisor_ip in hypervisors:
             try:
-                stats = self._ovs_memory_show_stats(hypervisor_ip)
-                if not stats:
-                    continue
-                if show_key and show_key not in stats:
-                    continue
-                found.append(hypervisor_ip)
+                for cmd in MEMORY_SHOW_COMMANDS:
+                    output = self._ssh_run_on_hypervisor(
+                        hypervisor_ip, cmd, check_rc=False)
+                    if output and output.strip():
+                        found.append(hypervisor_ip)
+                        break
             except Exception as exc:
                 LOG.warning(
                     'No memory/show on %s: %s', hypervisor_ip, exc)
@@ -1628,23 +1635,15 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                     hypervisor_ip)
             stats = self._ovs_memory_show_stats(
                 hypervisor_ip, output=show_output)
-            expected = stats.get(show_key)
+            expected = self._memory_show_expected_value(stats, show_key)
             reported = self._memory_live_metric_value(
                 hypervisor_ip, metric_name, metrics_output=metrics_output)
             try:
-                self.assertIsNotNone(
-                    expected,
-                    'memory/show missing %s on %s (show output: %r)' % (
-                        show_key, hypervisor_ip, show_output[:300]))
-                self.assertIsNotNone(
-                    reported,
-                    '%s missing on live :9105 on %s' % (
-                        metric_name, hypervisor_ip))
                 self.assertEqual(
                     expected, reported,
-                    '%s on %s: memory/show %s=%s live=%s' % (
+                    '%s on %s: memory/show %s=%s live=%s (show output: %r)' % (
                         metric_name, hypervisor_ip, show_key,
-                        expected, reported))
+                        expected, reported, show_output[:300]))
                 LOG.warning(
                     'Memory %s aligned with memory/show on %s (attempt %s): '
                     'show=%s live=%s',
@@ -1673,13 +1672,11 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             hypervisors,
             'No compute hypervisors available for memory metric %s' % (
                 metric_name))
-        show_key = OVS_MEMORY_METRIC_TO_SHOW_KEY[metric_name]
-        memory_hypervisors = self._hypervisors_with_memory_show(
-            hypervisors, show_key=show_key)
+        memory_hypervisors = self._hypervisors_with_memory_show(hypervisors)
         self.assertNotEmpty(
             memory_hypervisors,
-            'No memory/show %s on hypervisors %s for %s' % (
-                show_key, hypervisors, metric_name))
+            'No memory/show output on hypervisors %s for %s' % (
+                hypervisors, metric_name))
         last_exc = None
         for hypervisor_ip in memory_hypervisors:
             try:

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -510,9 +510,12 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             return self._send_ping_packets_bound_batched(
                 ssh_client, bind_ip, dest_ip, count, min_packets,
                 accept_xmit_only=accept_xmit_only)
-        return self._send_ping_packets_bound_once(
+        output = self._send_ping_packets_bound_once(
             ssh_client, bind_ip, dest_ip, count, min_packets,
             accept_xmit_only=accept_xmit_only)
+        if accept_xmit_only:
+            return self._parse_ping_transmitted(output)
+        return output
 
     def _send_ping_packets_bound_batched(self, ssh_client, bind_ip, dest_ip,
                                          count, min_packets,
@@ -539,6 +542,7 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             LOG.warning(
                 'Bound ping xmit-only flood: %d/%d transmitted %s -> %s',
                 total_xmit, count, bind_ip, dest_ip)
+            return total_xmit
         return last_output
 
     def _send_ping_packets_bound_once(self, ssh_client, bind_ip, dest_ip, count,

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -144,6 +144,9 @@ PING_MAX_WALL_SECONDS = 120
 # Routed fast ping needs interval plus RTT per reply; 30s caps ~3k of 5k probes.
 PING_FAST_FLOOD_PER_PACKET_SEC = 0.01
 PING_FAST_FLOOD_MIN_WALL_SECONDS = 90
+# Tempest SSH exec often returns after ~30s; batch routed floods to stay under it.
+PING_FAST_BATCH_PACKETS = 600
+PING_FAST_BATCH_MAX_WALL_SECONDS = 25
 
 
 class NetworkExporterMetricsBase(base_test.BaseTest):
@@ -396,6 +399,12 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             PING_FAST_FLOOD_MIN_WALL_SECONDS,
             int(count * PING_FAST_FLOOD_PER_PACKET_SEC) + 30)
 
+    def _ping_fast_batch_wall_seconds(self, batch_count):
+        """Per-batch wall clock kept under typical Tempest SSH exec limits."""
+        return min(
+            PING_FAST_BATCH_MAX_WALL_SECONDS,
+            max(20, int(batch_count * PING_FAST_FLOOD_PER_PACKET_SEC) + 15))
+
     def _send_ping_packets(self, ssh_client, dest_ip, count, min_packets):
         """Send ICMP echo requests between guests for traffic counter tests.
 
@@ -472,13 +481,42 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
     def _send_ping_packets_bound(self, ssh_client, bind_ip, dest_ip, count,
                                  min_packets):
         """Send ICMP echo requests bound to a specific source address."""
+        if (count > PING_FAST_BATCH_PACKETS and
+                self._guest_has_passwordless_sudo(ssh_client)):
+            return self._send_ping_packets_bound_batched(
+                ssh_client, bind_ip, dest_ip, count, min_packets)
+        return self._send_ping_packets_bound_once(
+            ssh_client, bind_ip, dest_ip, count, min_packets)
+
+    def _send_ping_packets_bound_batched(self, ssh_client, bind_ip, dest_ip,
+                                         count, min_packets):
+        """Send a large bound ping flood in SSH-friendly batches."""
+        remaining = count
+        last_output = ''
+        batch_num = 0
+        while remaining > 0:
+            batch_num += 1
+            batch = min(PING_FAST_BATCH_PACKETS, remaining)
+            LOG.warning(
+                'Bound ping batch %d: %d packets (%d remaining)',
+                batch_num, batch, remaining - batch)
+            last_output = self._send_ping_packets_bound_once(
+                ssh_client, bind_ip, dest_ip, batch, min_packets=1,
+                fast_wall=self._ping_fast_batch_wall_seconds(batch))
+            remaining -= batch
+        return last_output
+
+    def _send_ping_packets_bound_once(self, ssh_client, bind_ip, dest_ip, count,
+                                      min_packets, fast_wall=None):
+        """Send one bound ping command (single SSH exec)."""
         errors = []
         if self._guest_has_passwordless_sudo(ssh_client):
+            wall = (fast_wall if fast_wall is not None else
+                    self._ping_fast_flood_wall_seconds(count))
             for template in (
                     'timeout %d sudo -n ping -c %d -I %s -i %g -W 2 %s',
                     'ping -c %d -I %s -i %g -W 2 %s'):
                 if 'sudo' in template:
-                    wall = self._ping_fast_flood_wall_seconds(count)
                     cmd = template % (
                         wall, count, bind_ip, PING_FAST_INTERVAL_SEC, dest_ip)
                 else:

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -238,6 +238,16 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             })
         return samples, error
 
+    def _metric_show_output_usable(self, metric_name, stdout):
+        """True when pod exec or PromQL output contains metric_name samples."""
+        stdout = stdout or ''
+        return bool(stdout.strip()) and metric_name in stdout
+
+    def _metric_show_output_usable(self, metric_name, stdout):
+        """True when PromQL output contains metric_name samples."""
+        stdout = stdout or ''
+        return bool(stdout.strip()) and metric_name in stdout
+
     def _metric_show(self, metric_name):
         """Query metric-storage Prometheus for metric values."""
         query = 'last_over_time(%s[5m])' % metric_name
@@ -249,6 +259,9 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 LOG.warning("Prometheus query failed: %s", error)
                 return '', error, 1
             stdout = self._prometheus_results_to_table(results)
+            if not self._metric_show_output_usable(metric_name, stdout):
+                return '', (
+                    'metric-storage returned no samples for %s' % metric_name), 1
             return stdout, '', 0
         except Exception as exc:
             LOG.warning("Prometheus query error: %s", exc)

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -125,10 +125,11 @@ OVN_CONTROLLER_METRICS_CONTAINER = 'ovn-controller-metrics'
 OVN_CONTROLLER_METRICS_CURL = (
     'curl -sk https://127.0.0.1:1981/metrics 2>/dev/null || '
     'curl -s http://127.0.0.1:1981/metrics 2>/dev/null')
+PROM_NUMBER_RE = r'-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?'
 PROM_METRIC_LINE_RE = re.compile(
     r'^(?P<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)'
     r'\{(?P<labels>[^}]*)\}\s+'
-    r'(?P<value>-?\d+(?:\.\d+)?)$')
+    r'(?P<value>' + PROM_NUMBER_RE + r')$')
 PROM_LABEL_RE = re.compile(r'(\w+)="([^"]*)"')
 # openstack-network-exporter: 0=standby, 1=active, 2=paused
 OVN_NORTHD_STATUS_VALUES = (0, 1, 2)
@@ -171,6 +172,11 @@ PING_FAST_BATCH_MAX_WALL_SECONDS = 25
 
 class NetworkExporterMetricsBase(base_test.BaseTest):
     """Shared helpers for openstack-network-exporter Tempest tests."""
+
+    @staticmethod
+    def _parse_prom_number(value_str):
+        """Parse a Prometheus numeric sample (supports scientific notation)."""
+        return int(float(value_str))
 
     def __init__(self, *args, **kwargs):
         super(NetworkExporterMetricsBase, self).__init__(*args, **kwargs)
@@ -1441,26 +1447,25 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
 
     def _prom_compute_metric_value(self, hypervisor_ip, metric_name, labels):
         """Read one gauge from the local :9105 scrape matching Prometheus labels."""
+        value_pattern = re.compile(
+            r'%s\{[^}]*\}\s+(%s)\s*$' % (
+                re.escape(metric_name), PROM_NUMBER_RE))
         grep = "grep '^%s{'" % metric_name
         for key in sorted(labels):
             grep += " | grep '%s=\"%s\"'" % (key, labels[key])
-        cmd = (
-            "curl -sk https://127.0.0.1:9105/metrics 2>/dev/null | %s" % grep)
-        out = self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
-        pattern = re.compile(
-            r'%s\{[^}]*\}\s+(-?\d+(?:\.\d+)?)' % re.escape(metric_name))
-        for line in out.splitlines():
-            match = pattern.search(line)
-            if match:
-                return int(float(match.group(1)))
-        cmd_http = (
-            "curl -s http://127.0.0.1:9105/metrics 2>/dev/null | %s" % grep)
-        out = self._ssh_run_on_hypervisor(hypervisor_ip, cmd_http)
-        for line in out.splitlines():
-            match = pattern.search(line)
-            if match:
-                return int(float(match.group(1)))
-        return None
+        for cmd in (
+                "curl -sk https://127.0.0.1:9105/metrics 2>/dev/null | %s"
+                % grep,
+                "curl -s http://127.0.0.1:9105/metrics 2>/dev/null | %s"
+                % grep):
+            out = self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
+            for line in out.splitlines():
+                match = value_pattern.search(line.strip())
+                if match:
+                    return self._parse_prom_number(match.group(1))
+        return self._parse_prom_metric_text(
+            self._scrape_compute_metrics_text(hypervisor_ip),
+            metric_name, labels)
 
     def _parse_prom_metric_text(self, metrics_output, metric_name, labels):
         """Parse a gauge from Prometheus exposition text."""
@@ -1473,7 +1478,7 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
             parts = line.rsplit(None, 1)
             if len(parts) == 2:
                 try:
-                    return int(float(parts[1]))
+                    return self._parse_prom_number(parts[1])
                 except ValueError:
                     continue
         return None
@@ -1766,6 +1771,6 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 continue
             samples.append({
                 'labels': labels,
-                'value': int(float(match.group('value'))),
+                'value': self._parse_prom_number(match.group('value')),
             })
         return samples

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/metrics_base.py
@@ -804,10 +804,6 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
 
     def _assert_router_port_metric_reported(self, metric_name):
         """Assert ovnc_router_port_traffic_* via openstack metric show and storage."""
-        self._assert_ovn_controller_metric_reported(metric_name)
-
-    def _assert_ovn_controller_metric_reported(self, metric_name):
-        """Assert OVN :1981 metrics via metric show, storage, and live scrape."""
         self._assert_metric_reported(metric_name)
         storage_samples, query_error = self._metric_storage_samples(metric_name)
         self.assertNotEmpty(
@@ -817,8 +813,75 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
         if not self._metric_on_ovn_scrape(metric_name):
             LOG.warning(
                 '%s present in metric-storage but not on a Tempest-reachable '
-                'OVN :1981 scrape',
+                'OVN :1981 scrape; router port tests use metric-storage',
                 metric_name)
+
+    def _assert_ovn_controller_metric_best_effort(self, metric_name):
+        """Best-effort federation check; require live OVN :1981 scrape."""
+        stdout, stderr, returncode = self._metric_show(metric_name)
+        stdout = stdout or ''
+        if self._metric_show_output_usable(metric_name, stdout):
+            LOG.info(
+                "Metric '%s' reported via openstack metric show or "
+                "metric-storage fallback", metric_name)
+        else:
+            LOG.warning(
+                "openstack metric show unavailable for '%s' (exit %s: %s); "
+                "continuing with live OVN :1981 scrape",
+                metric_name, returncode, stderr)
+        storage_samples, query_error = self._metric_storage_samples(metric_name)
+        if storage_samples:
+            LOG.info(
+                "Metric '%s' present in metric-storage (%s samples)",
+                metric_name, len(storage_samples))
+        else:
+            LOG.warning(
+                '%s missing from metric-storage Prometheus (query: %s); '
+                'continuing with live OVN :1981 scrape',
+                metric_name, query_error)
+        self.assertTrue(
+            self._metric_on_ovn_scrape(metric_name),
+            "Metric '%s' not found on a Tempest-reachable OVN :1981 scrape"
+            % metric_name)
+
+    def _assert_ovnc_txn_presence(self, metric_name):
+        """Assert ovnc_txn_* path via live :1981 or coverage/show (not federated)."""
+        coverage_key = OVNC_TXN_METRIC_TO_COVERAGE_KEY[metric_name]
+        storage_samples, query_error = self._metric_storage_samples(metric_name)
+        if not storage_samples:
+            LOG.warning(
+                '%s not federated to metric-storage (%s); using live OVN '
+                'scrape and coverage/show',
+                metric_name, query_error)
+
+        hypervisors = self._get_ssh_hypervisors('')
+        ovn_hypervisors = self._hypervisors_with_ovn_controller(hypervisors)
+        self.assertNotEmpty(
+            ovn_hypervisors,
+            'No OVN controller on hypervisors %s for %s' % (
+                hypervisors, metric_name))
+
+        found_on = []
+        for hypervisor_ip in ovn_hypervisors:
+            if self._ovnc_live_samples(hypervisor_ip, metric_name):
+                found_on.append(hypervisor_ip)
+                continue
+            try:
+                totals = self._ovn_coverage_totals(hypervisor_ip)
+                if coverage_key in totals or totals:
+                    found_on.append(hypervisor_ip)
+            except Exception as exc:
+                LOG.warning(
+                    'No coverage/show for %s on %s: %s',
+                    metric_name, hypervisor_ip, exc)
+        self.assertNotEmpty(
+            found_on,
+            "Metric '%s' not on OVN :1981 scrape and no coverage/show txn "
+            "stats on hypervisors %s" % (metric_name, ovn_hypervisors))
+        LOG.info(
+            "Metric '%s' reachable on hypervisor(s) %s via :1981 or "
+            "coverage/show",
+            metric_name, found_on)
 
     def _router_port_label_key(self, labels):
         """Stable identity for ovnc_router_port_traffic series."""
@@ -1948,8 +2011,8 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                     sample['value']))
 
     def _assert_ovnc_config_metric_reported(self, metric_name):
-        """Assert ovnc_* config via metric show, storage, and external_ids."""
-        self._assert_ovn_controller_metric_reported(metric_name)
+        """Assert ovnc_* config via live :1981 and ovs-vsctl external_ids."""
+        self._assert_ovn_controller_metric_best_effort(metric_name)
         hypervisors = self._get_ssh_hypervisors('')
         self.assertNotEmpty(
             hypervisors,
@@ -2035,8 +2098,8 @@ class NetworkExporterMetricsBase(base_test.BaseTest):
                 metric_name, hypervisor_ip))
 
     def _assert_ovnc_txn_metric_reported(self, metric_name):
-        """Assert ovnc_txn_* via metric show, storage, and coverage/show."""
-        self._assert_ovn_controller_metric_reported(metric_name)
+        """Assert ovnc_txn_* via live :1981 and coverage/show."""
+        self._assert_ovnc_txn_presence(metric_name)
         hypervisors = self._get_ssh_hypervisors('')
         self.assertNotEmpty(
             hypervisors,

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/net_vf_metrics_mixin.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/net_vf_metrics_mixin.py
@@ -1,0 +1,806 @@
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Reusable net_vf metric validation helpers for SR-IOV VF Tempest tests."""
+
+import shlex
+import time
+import unittest
+
+from nfv_tempest_plugin.tests.common import shell_utilities as shell_utils
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class NetVfMetricsMixin(object):
+    """Validate net_vf_* metrics against compute :9105, metric-storage, and sysfs."""
+
+    def _metrics_text_from_hypervisor(self, hypervisor_ip):
+        return self._scrape_compute_metrics_text(hypervisor_ip)
+
+    def _assert_net_vf_metric_reported(self, metric_name):
+        """Assert net_vf* on compute :9105 and in metric-storage Prometheus."""
+        stdout, stderr, returncode = self._metric_show(metric_name)
+        stdout = stdout or ''
+        hypervisor_ip = None
+        if (returncode == 0 and metric_name in stdout and
+                metrics_base.NETWORK_EXPORTER_INSTANCE_PORT in stdout):
+            LOG.warning(
+                "Metric '%s' reported via openstack metric show", metric_name)
+            hypervisors = self._hypervisor_ips_from_metric_stdout(stdout)
+            if hypervisors:
+                hypervisor_ip = hypervisors[0]
+        else:
+            LOG.warning(
+                "openstack metric show unavailable for '%s' (exit %s: %s); "
+                "falling back to compute :9105 SSH scrape",
+                metric_name, returncode, stderr)
+            self._assert_metric_on_compute_scrape(metric_name)
+        if not hypervisor_ip:
+            hypervisor_ip = self._hypervisor_for_net_vf_metric(metric_name)
+        self.assertIsNotNone(
+            hypervisor_ip,
+            "Could not find a hypervisor exporting %s on compute :9105" %
+            metric_name)
+        self._assert_net_vf_metric_present_in_metric_storage(
+            hypervisor_ip, metric_name)
+        return stdout
+
+    def _prom_samples(self, hypervisor_ip, metric_name, required_labels=None,
+                      metrics_output=None):
+        if metrics_output is None:
+            metrics_output = self._metrics_text_from_hypervisor(hypervisor_ip)
+        return self._parse_prom_samples(
+            metrics_output, metric_name, required_labels)
+
+    def _net_vf_sample_key(self, labels):
+        """Stable VF identity shared by compute scrape and metric-storage."""
+        return (labels.get('device'), labels.get('vf'),
+                labels.get('pci_address'))
+
+    def _hypervisor_for_net_vf_metric(self, metric_name):
+        """Return a hypervisor IP that exports metric_name on compute :9105."""
+        for hypervisor_ip in self._get_hypervisor_ip_from_undercloud():
+            if self._prom_samples(hypervisor_ip, metric_name):
+                return hypervisor_ip
+        return None
+
+    def _vf_identity_labels(self, vf_labels):
+        """Label subset used to match one VF across compute and metric-storage."""
+        if not vf_labels:
+            return None
+        return {key: vf_labels[key]
+                for key in ('device', 'vf', 'pci_address')
+                if key in vf_labels}
+
+    def _assert_net_vf_metric_present_in_metric_storage(
+            self, hypervisor_ip, metric_name):
+        """Verify metric series exist on compute :9105 and in metric-storage."""
+        compute_samples = self._prom_samples(hypervisor_ip, metric_name)
+        self.assertNotEmpty(
+            compute_samples,
+            "No %s samples on compute :9105 for %s" % (
+                metric_name, hypervisor_ip))
+        storage_samples, query_error = self._metric_storage_samples(
+            metric_name, hypervisor_ip=hypervisor_ip)
+        self.assertNotEmpty(
+            storage_samples,
+            "%s missing from metric-storage Prometheus for %s "
+            "(compute had %d series). Query error: %s" % (
+                metric_name, hypervisor_ip, len(compute_samples),
+                query_error))
+        compute_keys = {
+            self._net_vf_sample_key(sample['labels'])
+            for sample in compute_samples}
+        storage_keys = {
+            self._net_vf_sample_key(sample['labels'])
+            for sample in storage_samples}
+        overlap = compute_keys & storage_keys
+        self.assertNotEmpty(
+            overlap,
+            "%s on %s: no VF series in common between compute :9105 and "
+            "metric-storage (compute=%d storage=%d series). "
+            "Sample compute keys: %s; storage keys: %s" % (
+                metric_name, hypervisor_ip, len(compute_keys),
+                len(storage_keys), sorted(compute_keys)[:3],
+                sorted(storage_keys)[:3]))
+        LOG.warning(
+            "%s on %s present in compute :9105 and metric-storage "
+            "(%d common VF series of compute=%d storage=%d)",
+            metric_name, hypervisor_ip, len(overlap),
+            len(compute_keys), len(storage_keys))
+
+    def _assert_net_vf_metrics_match_metric_storage(
+            self, hypervisor_ip, metric_name, vf_labels=None):
+        """Compare net_vf* values on compute :9105 vs metric-storage for VF(s)."""
+        identity_labels = self._vf_identity_labels(vf_labels)
+        self.assertIsNotNone(
+            identity_labels,
+            '_assert_net_vf_metrics_match_metric_storage requires vf_labels '
+            'to identify the VF under test')
+        last_detail = ''
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            compute_output = self._metrics_text_from_hypervisor(hypervisor_ip)
+            compute_samples = self._prom_samples(
+                hypervisor_ip, metric_name, identity_labels,
+                metrics_output=compute_output)
+            storage_samples, query_error = self._metric_storage_samples(
+                metric_name, hypervisor_ip=hypervisor_ip,
+                required_labels=identity_labels)
+            if not compute_samples:
+                last_detail = (
+                    'no compute samples for labels %s' % identity_labels)
+            elif not storage_samples:
+                last_detail = (
+                    'no metric-storage samples for labels %s (%s)' % (
+                        identity_labels, query_error))
+            else:
+                storage_by_key = {
+                    self._net_vf_sample_key(sample['labels']): sample['value']
+                    for sample in storage_samples}
+                mismatches = []
+                for sample in compute_samples:
+                    key = self._net_vf_sample_key(sample['labels'])
+                    compute_value = sample['value']
+                    if key not in storage_by_key:
+                        mismatches.append(
+                            'VF %s on compute :9105 but missing in '
+                            'metric-storage' % (key,))
+                        continue
+                    storage_value = storage_by_key[key]
+                    if compute_value != storage_value:
+                        mismatches.append(
+                            'VF %s on %s: compute :9105=%s, '
+                            'metric-storage=%s' % (
+                                key, hypervisor_ip, compute_value,
+                                storage_value))
+                if not mismatches:
+                    LOG.warning(
+                        "%s on %s matches between compute :9105 and "
+                        "metric-storage for labels %s",
+                        metric_name, hypervisor_ip, identity_labels)
+                    return
+                last_detail = '\n'.join(mismatches)
+            LOG.warning(
+                "Attempt %s/%s waiting for %s metric-storage sync on %s: %s",
+                attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                metric_name, hypervisor_ip, last_detail)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            "%s mismatch between compute and metric-storage on %s "
+            "(labels=%s): %s" % (
+                metric_name, hypervisor_ip, identity_labels, last_detail))
+
+    def _vf_labels_from_mac(self, hypervisor_ip, mac_address):
+        vf_ref = shell_utils.get_vf_from_mac(mac_address, hypervisor_ip)
+        if not vf_ref or "_" not in vf_ref:
+            raise unittest.SkipTest(
+                "Could not map MAC %s to host VF on %s. "
+                "Ensure direct SR-IOV ports are present." % (
+                    mac_address, hypervisor_ip))
+        device, vf = vf_ref.rsplit("_", 1)
+        device = device.strip()
+        vf = vf.strip()
+        pci_cmd = (
+            "basename \"$(readlink -f /sys/class/net/%s/device/virtfn%s)\" "
+            "2>/dev/null" % (device, vf))
+        pci_address = self._ssh_run_on_hypervisor(
+            hypervisor_ip, pci_cmd).strip()
+        if not pci_address:
+            raise unittest.SkipTest(
+                "Could not read VF PCI address for %s vf %s on %s" % (
+                    device, vf, hypervisor_ip))
+        numa_cmd = (
+            "cat /sys/bus/pci/devices/%s/numa_node 2>/dev/null" % pci_address)
+        numa_node = self._ssh_run_on_hypervisor(hypervisor_ip, numa_cmd).strip()
+        return {
+            "device": device,
+            "vf": vf,
+            "pci_address": pci_address,
+            "numa_node": numa_node if numa_node else "-1",
+        }
+
+    def _counter_value(self, hypervisor_ip, metric_name, vf_labels):
+        """Read one net_vf counter from compute :9105 for a single VF."""
+        identity = self._vf_identity_labels(vf_labels)
+        samples = self._prom_samples(
+            hypervisor_ip, metric_name, required_labels=identity)
+        if not samples:
+            return None
+        if len(samples) > 1:
+            self.fail(
+                '%s on %s matched multiple VF series for labels %s: %s' % (
+                    metric_name, hypervisor_ip, identity,
+                    [self._net_vf_sample_key(s['labels']) for s in samples]))
+        return samples[0]['value']
+
+    def _storage_counter_value(self, hypervisor_ip, metric_name, vf_labels):
+        """Read one net_vf counter from metric-storage for a single VF."""
+        identity = self._vf_identity_labels(vf_labels)
+        samples, query_error = self._metric_storage_samples(
+            metric_name, hypervisor_ip=hypervisor_ip,
+            required_labels=identity)
+        if not samples:
+            LOG.warning(
+                'No metric-storage sample for %s on %s labels %s: %s',
+                metric_name, hypervisor_ip, identity, query_error)
+            return None
+        if len(samples) > 1:
+            self.fail(
+                '%s in metric-storage on %s matched multiple VF series for '
+                'labels %s' % (metric_name, hypervisor_ip, identity))
+        return samples[0]['value']
+
+    def _vf_promql_filter(self, hypervisor_ip, vf_labels, metric_name):
+        """Return a PromQL snippet for the VF under test (for failure logs)."""
+        identity = self._vf_identity_labels(vf_labels)
+        parts = ['instance="%s%s"' % (
+            hypervisor_ip, metrics_base.NETWORK_EXPORTER_INSTANCE_PORT)]
+        for key in ('device', 'vf', 'pci_address'):
+            if key in identity:
+                parts.append('%s="%s"' % (key, identity[key]))
+        return '%s{%s}' % (metric_name, ','.join(parts))
+
+    def _ssh_run_unchecked_on_hypervisor(self, hypervisor_ip, command):
+        """Run on hypervisor without failing the test (cleanup helpers)."""
+        try:
+            return self._ssh_run_on_hypervisor(hypervisor_ip, command)
+        except Exception as exc:
+            LOG.warning(
+                'Unchecked hypervisor command on %s failed: %s (%s)',
+                hypervisor_ip, command, exc)
+            return ''
+
+    def _lookup_guest_dataplane_iface_by_mac(self, ssh_client, mac_address):
+        """Return guest netdev for a MAC, or None if not found."""
+        mac = mac_address.lower()
+        cmd = (
+            "ip -o link | grep -i '%s' | awk -F': ' '{print $2; exit}'" % mac)
+        raw = ssh_client.exec_command(cmd).strip()
+        iface = raw.split('@')[0].strip() if raw else ''
+        return iface or None
+
+    def _lookup_guest_dataplane_iface_by_ip(self, ssh_client, ip_address):
+        """Return guest netdev carrying a fixed IP, or None if not found."""
+        if ':' in ip_address:
+            match = "inet6 %s/" % ip_address
+        else:
+            match = "inet %s/" % ip_address
+        cmd = (
+            "ip -o addr show | grep '%s' | awk '{print $2; exit}'" % match)
+        raw = ssh_client.exec_command(cmd).strip()
+        return raw.split('@')[0].strip() if raw else None
+
+    def _guest_dataplane_iface(self, ssh_client, mac_address):
+        """Return the guest netdev name for an SR-IOV port MAC address."""
+        iface = self._lookup_guest_dataplane_iface_by_mac(
+            ssh_client, mac_address)
+        if not iface:
+            raise unittest.SkipTest(
+                'Could not resolve guest dataplane interface for MAC %s' % (
+                    mac_address))
+        return iface
+
+    def _guest_dataplane_iface_for_port(self, ssh_client, port):
+        """Locate SR-IOV dataplane netdev by port MAC, else by fixed IP."""
+        iface = self._lookup_guest_dataplane_iface_by_mac(
+            ssh_client, port['mac_address'])
+        if iface:
+            return iface
+        fixed_ips = port.get('fixed_ips') or []
+        if fixed_ips:
+            iface = self._lookup_guest_dataplane_iface_by_ip(
+                ssh_client, fixed_ips[0]['ip_address'])
+            if iface:
+                return iface
+        raise unittest.SkipTest(
+            'Could not resolve guest dataplane interface for port MAC %s '
+            'and fixed IPs %s' % (
+                port['mac_address'],
+                [ip['ip_address'] for ip in fixed_ips]))
+
+    @staticmethod
+    def _is_zero_mac(mac_address):
+        """Return True when a MAC is unset (all zeros)."""
+        mac = (mac_address or '').lower().replace('-', ':')
+        return mac in ('00:00:00:00:00:00',)
+
+    def _read_guest_iface_mac(self, ssh_client, iface):
+        """Return the MAC address from guest sysfs for one netdev."""
+        guest_mac = ssh_client.exec_command(
+            'cat /sys/class/net/%s/address' % iface).strip().lower()
+        if not guest_mac:
+            raise unittest.SkipTest(
+                'Could not read MAC from guest interface %s' % iface)
+        return guest_mac
+
+    def _guest_dataplane_mac(self, ssh_client, mac_address):
+        """Return the MAC address read from the guest SR-IOV netdev."""
+        iface = self._guest_dataplane_iface(ssh_client, mac_address)
+        guest_mac = self._read_guest_iface_mac(ssh_client, iface)
+        return guest_mac, iface
+
+    def _assert_guest_port_mac(self, ssh_client, port, server):
+        """Verify the VM dataplane interface MAC matches the Neutron port."""
+        expected_mac = port['mac_address'].lower()
+        guest_mac, iface = self._guest_dataplane_mac(
+            ssh_client, expected_mac)
+        self.assertEqual(
+            guest_mac, expected_mac,
+            'Guest SR-IOV MAC mismatch on server %s interface %s: '
+            'Neutron port=%s guest=%s' % (
+                server['id'], iface, expected_mac, guest_mac))
+        LOG.warning(
+            'Guest SR-IOV MAC verified on server %s: interface=%s mac=%s',
+            server['id'], iface, guest_mac)
+
+    def _assert_guest_port_mac_not_zero(self, ssh_client, port, server):
+        """Fail when the guest SR-IOV dataplane NIC MAC is all zeros."""
+        iface = self._guest_dataplane_iface_for_port(ssh_client, port)
+        guest_mac = self._read_guest_iface_mac(ssh_client, iface)
+        self.assertFalse(
+            self._is_zero_mac(guest_mac),
+            'Guest SR-IOV interface %s on server %s has all-zero MAC %s '
+            '(Neutron port MAC %s). The VF MAC was not programmed in the '
+            'guest.' % (
+                iface, server['id'], guest_mac, port['mac_address']))
+        LOG.warning(
+            'Guest SR-IOV MAC is non-zero on server %s: interface=%s mac=%s',
+            server['id'], iface, guest_mac)
+
+    @staticmethod
+    def _parse_vf_sysfs_stats_blob(blob):
+        """Parse mlx5-style VF stats file (``tx_dropped : 123`` per line)."""
+        stats = {}
+        for line in (blob or '').splitlines():
+            line = line.strip()
+            if not line or ':' not in line:
+                continue
+            key, _, value = line.partition(':')
+            key = key.strip()
+            value = value.strip()
+            try:
+                stats[key] = int(value)
+            except ValueError:
+                continue
+        return stats
+
+    def _pf_netdevices_for_vf(self, hypervisor_ip, vf_labels):
+        """Return PF netdev name(s) that host VF stats under .../sriov/<vf>/stats."""
+        devices = []
+        seen = set()
+
+        def add(name):
+            name = (name or '').strip()
+            if name and name not in seen:
+                seen.add(name)
+                devices.append(name)
+
+        add(vf_labels['device'])
+        pci = vf_labels.get('pci_address')
+        if not pci:
+            return devices
+        pf_net_cmd = (
+            'bash -c %s' % shlex.quote(
+                'pf=$(readlink -f /sys/bus/pci/devices/%s/physfn 2>/dev/null); '
+                'if [ -n "$pf" ]; then ls "$pf/net" 2>/dev/null; fi' % pci))
+        for line in self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, pf_net_cmd).splitlines():
+            add(line)
+
+        pci_net_cmd = (
+            'bash -c %s' % shlex.quote(
+                'ls /sys/bus/pci/devices/%s/net 2>/dev/null' % pci))
+        for line in self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, pci_net_cmd).splitlines():
+            add(line)
+        return devices
+
+    def _pf_netdev_for_vf_admin(self, hypervisor_ip, vf_labels):
+        """Return PF netdev for ``ip link set dev <pf> vf <n> ...`` on the host."""
+        pci = vf_labels.get('pci_address')
+        if pci:
+            pf_net_cmd = (
+                'bash -c %s' % shlex.quote(
+                    'pf=$(readlink -f /sys/bus/pci/devices/%s/physfn '
+                    '2>/dev/null); '
+                    'if [ -n "$pf" ]; then ls "$pf/net" 2>/dev/null | head -1; '
+                    'fi' % pci))
+            pf_netdev = self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, pf_net_cmd).strip()
+            if pf_netdev:
+                return pf_netdev
+        return vf_labels['device']
+
+    def _vf_sysfs_stats_bases(self, hypervisor_ip, vf_labels):
+        """Candidate sysfs paths for one VF stats file or directory."""
+        vf = vf_labels['vf']
+        bases = []
+        seen = set()
+
+        def add(path):
+            if path not in seen:
+                seen.add(path)
+                bases.append(path)
+
+        for pf_dev in self._pf_netdevices_for_vf(hypervisor_ip, vf_labels):
+            add('/sys/class/net/%s/device/sriov/%s/stats' % (pf_dev, vf))
+            add('/sys/class/net/%s/device/sriov/vf%s/stats' % (pf_dev, vf))
+
+        ib_cmd = (
+            'bash -c %s' % shlex.quote(
+                'for ib in /sys/class/infiniband/*/device; do '
+                'test -e "$ib/sriov/%s/stats" && echo "$ib/sriov/%s/stats"; '
+                'done' % (vf, vf)))
+        for line in self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, ib_cmd).splitlines():
+            add(line.strip())
+        return bases
+
+    def _vf_sysfs_stat_file_paths(self, hypervisor_ip, vf_labels, stat_name):
+        """Per-stat sysfs files (Intel-style .../sriov/N/stats/rx_dropped)."""
+        vf = vf_labels['vf']
+        paths = []
+        seen = set()
+        for pf_dev in self._pf_netdevices_for_vf(hypervisor_ip, vf_labels):
+            for path in (
+                    '/sys/class/net/%s/device/sriov/%s/stats/%s' % (
+                        pf_dev, vf, stat_name),
+                    '/sys/class/net/%s/device/sriov/vf%s/stats/%s' % (
+                        pf_dev, vf, stat_name)):
+                if path not in seen:
+                    seen.add(path)
+                    paths.append(path)
+        return paths
+
+    def _read_vf_stats_at_base(self, hypervisor_ip, stats_base):
+        """Read VF stats from one sysfs file (mlx5 blob) or stats/ directory."""
+        script = (
+            'base=%s; '
+            'if [ -f "$base" ]; then cat "$base"; '
+            'elif [ -d "$base" ]; then '
+            '  for f in "$base"/*; do '
+            '    [ -f "$f" ] || continue; '
+            '    n=$(basename "$f"); v=$(cat "$f" 2>/dev/null); '
+            '    printf "%%s: %%s\\n" "$n" "$v"; '
+            '  done; '
+            'fi' % shlex.quote(stats_base))
+        blob = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip, 'bash -c %s' % shlex.quote(script)).strip()
+        if not blob or 'No such file' in blob:
+            return {}
+        return self._parse_vf_sysfs_stats_blob(blob)
+
+    def _host_vf_sysfs_stats_map(self, hypervisor_ip, vf_labels):
+        """Return all VF stats from host sysfs for the PF/VF under test."""
+        stats_bases = self._vf_sysfs_stats_bases(hypervisor_ip, vf_labels)
+        for stats_base in stats_bases:
+            stats = self._read_vf_stats_at_base(hypervisor_ip, stats_base)
+            if stats:
+                LOG.warning(
+                    'Read VF sysfs stats from %s on %s for labels %s: %s',
+                    stats_base, hypervisor_ip, vf_labels,
+                    sorted(stats.keys()))
+                return stats
+        LOG.warning(
+            'No VF sysfs stats found on %s for labels %s (tried: %s)',
+            hypervisor_ip, vf_labels, stats_bases)
+        return {}
+
+    def _host_vf_sysfs_stat(self, hypervisor_ip, vf_labels, stat_name):
+        """Read one VF counter from host sysfs (same source as net_vf exporter)."""
+        for path in self._vf_sysfs_stat_file_paths(
+                hypervisor_ip, vf_labels, stat_name):
+            raw = self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip,
+                'cat %s 2>/dev/null' % shlex.quote(path)).strip()
+            if raw.isdigit():
+                return int(raw)
+        return self._host_vf_sysfs_stats_map(hypervisor_ip, vf_labels).get(
+            stat_name)
+
+    def _host_vf_sysfs_stats_available(self, hypervisor_ip, vf_labels):
+        """Return sorted VF stat names exposed under host sysfs, or []."""
+        return sorted(self._host_vf_sysfs_stats_map(hypervisor_ip, vf_labels))
+
+    def _vf_prom_storage_values(self, hypervisor_ip, vf_labels, metric_name):
+        """Read one net_vf counter from compute :9105 and metric-storage."""
+        return (
+            self._counter_value(hypervisor_ip, metric_name, vf_labels),
+            self._storage_counter_value(hypervisor_ip, metric_name, vf_labels))
+
+    def _wait_for_vf_prom_storage_aligned(
+            self, hypervisor_ip, vf_labels, metric_name):
+        """Wait until :9105 and metric-storage match before taking a baseline."""
+        identity = self._vf_identity_labels(vf_labels)
+        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            prom, storage = self._vf_prom_storage_values(
+                hypervisor_ip, vf_labels, metric_name)
+            last = {'prom': prom, 'storage': storage}
+            if prom is not None and storage is not None and prom == storage:
+                LOG.warning(
+                    ':9105 and metric-storage aligned for %s on %s: %s. %s',
+                    metric_name, identity, prom, promql)
+                return prom, storage
+            LOG.warning(
+                'Attempt %s/%s waiting for :9105==metric-storage baseline '
+                'on %s for %s: %s',
+                attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                identity, metric_name, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            '%s on %s did not align across compute :9105 and metric-storage '
+            'before baseline for labels %s. Last %s. Per-VF PromQL: %s' % (
+                metric_name, hypervisor_ip, identity, last, promql))
+
+    def _wait_for_vf_prom_and_storage_increase(
+            self, hypervisor_ip, vf_labels, metric_name, baseline_prom,
+            counter_kind, min_delta=None, baseline_storage=None):
+        """Wait for net_vf counter growth on :9105 and metric-storage."""
+        if min_delta is None:
+            min_delta = (self._min_expected_packets()
+                         if counter_kind == 'packets'
+                         else self._min_expected_bytes())
+        if baseline_storage is None:
+            baseline_storage = self._storage_counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+        identity = self._vf_identity_labels(vf_labels)
+        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            prom = self._counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+            storage = self._storage_counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+            prom_delta = (
+                None if prom is None or baseline_prom is None
+                else prom - baseline_prom)
+            storage_delta = (
+                None if storage is None or baseline_storage is None
+                else storage - baseline_storage)
+            last = {
+                'baseline_prom': baseline_prom,
+                'baseline_storage': baseline_storage,
+                'prom': prom,
+                'storage': storage,
+                'prom_delta': prom_delta,
+                'storage_delta': storage_delta,
+                'min_delta': min_delta,
+            }
+            if (prom is not None and storage is not None and
+                    prom_delta is not None and storage_delta is not None and
+                    prom_delta >= min_delta and
+                    storage_delta >= min_delta and
+                    prom == storage):
+                LOG.warning(
+                    '%s on %s increased on compute and metric-storage for %s: '
+                    'value=%s (baseline prom=%s storage=%s, delta=%s). '
+                    'Dashboard filter: %s',
+                    metric_name, hypervisor_ip, identity, prom,
+                    baseline_prom, baseline_storage, prom_delta, promql)
+                return prom_delta
+            LOG.warning(
+                'Attempt %s/%s waiting for %s on %s (need prom/storage '
+                'delta>=%s and prom==storage): %s',
+                attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                metric_name, identity, min_delta, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            '%s on %s did not increase on both compute :9105 and '
+            'metric-storage for labels %s. Required delta>=%s and '
+            'prom==storage. Last %s. Per-VF PromQL: %s' % (
+                metric_name, hypervisor_ip, identity, min_delta, last, promql))
+
+    def _wait_for_vf_counter_aligned_with_sysfs(
+            self, hypervisor_ip, vf_labels, metric_name, sysfs_stat_name,
+            baseline_prom, baseline_sysfs, min_prom_delta, min_sysfs_delta):
+        """Wait until :9105, metric-storage, and sysfs all match for one VF."""
+        identity = self._vf_identity_labels(vf_labels)
+        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            sysfs_now = self._host_vf_sysfs_stat(
+                hypervisor_ip, vf_labels, sysfs_stat_name)
+            prom = self._counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+            storage = self._storage_counter_value(
+                hypervisor_ip, metric_name, vf_labels)
+            sysfs_delta = (
+                None if sysfs_now is None or baseline_sysfs is None
+                else sysfs_now - baseline_sysfs)
+            prom_delta = (
+                None if prom is None or baseline_prom is None
+                else prom - baseline_prom)
+            last = {
+                'baseline_prom': baseline_prom,
+                'baseline_sysfs': baseline_sysfs,
+                'sysfs_now': sysfs_now,
+                'sysfs_delta': sysfs_delta,
+                'prom': prom,
+                'prom_delta': prom_delta,
+                'storage': storage,
+                'min_prom_delta': min_prom_delta,
+                'min_sysfs_delta': min_sysfs_delta,
+            }
+            if None in (sysfs_now, prom, storage, sysfs_delta, prom_delta):
+                LOG.warning(
+                    'Attempt %s/%s waiting for %s alignment on %s: %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    metric_name, identity, last)
+            elif (sysfs_delta >= min_sysfs_delta and
+                  prom_delta >= min_prom_delta and
+                  prom == storage == sysfs_now):
+                LOG.warning(
+                    '%s aligned on %s for %s: sysfs/prom/storage=%s '
+                    '(baseline prom=%s sysfs=%s, deltas prom=%s sysfs=%s). '
+                    'Dashboard filter: %s',
+                    metric_name, hypervisor_ip, identity, prom,
+                    baseline_prom, baseline_sysfs, prom_delta, sysfs_delta,
+                    promql)
+                return prom, sysfs_now
+            else:
+                LOG.warning(
+                    'Attempt %s/%s %s not aligned on %s (need sysfs_delta>=%s '
+                    'prom_delta>=%s and prom==storage==sysfs): %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    metric_name, identity, min_sysfs_delta, min_prom_delta,
+                    last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            '%s on %s did not align across sysfs, compute :9105, and '
+            'metric-storage for labels %s. Required sysfs_delta>=%s '
+            'prom_delta>=%s and prom==storage==sysfs. Last %s. '
+            'Per-VF PromQL (not sum across all VFs): %s' % (
+                metric_name, hypervisor_ip, identity, min_sysfs_delta,
+                min_prom_delta, last, promql))
+
+    def _test_vf_drop_counter_increases(
+            self, metric_name, endpoint_role, traffic_generator,
+            sysfs_stat_name):
+        """Validate net_vf_*_dropped_total increases after induced drops."""
+        self._assert_net_vf_metric_reported(metric_name)
+        ctx = self._build_traffic_context()
+        endpoint = ctx[endpoint_role]
+        hypervisor_ip = endpoint['hypervisor_ip']
+        vf_labels = endpoint['vf_labels']
+        baseline_sysfs = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, sysfs_stat_name)
+        baseline_prom, baseline_storage = (
+            self._wait_for_vf_prom_storage_aligned(
+                hypervisor_ip, vf_labels, metric_name))
+        self.assertIsNotNone(
+            baseline_prom,
+            '%s missing baseline on %s for labels %s' % (
+                metric_name, hypervisor_ip, vf_labels))
+
+        packet_count = self._ping_count()
+        min_packets = self._min_expected_packets()
+        traffic_generator(ctx, packet_count, min_packets)
+
+        sysfs_before = ctx.get('sysfs_drop_before')
+        sysfs_after = ctx.get('sysfs_drop_after')
+        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+
+        if (sysfs_before is not None and sysfs_after is not None and
+                sysfs_after > sysfs_before):
+            sysfs_delta = sysfs_after - sysfs_before
+            baseline_sysfs_val = (
+                baseline_sysfs if baseline_sysfs is not None else sysfs_before)
+            final_prom, final_sysfs = (
+                self._wait_for_vf_counter_aligned_with_sysfs(
+                    hypervisor_ip, vf_labels, metric_name, sysfs_stat_name,
+                    baseline_prom, baseline_sysfs_val, sysfs_delta,
+                    sysfs_delta))
+            LOG.warning(
+                '%s validated with sysfs on %s for %s: prom/sysfs=%s '
+                '(baseline prom=%s sysfs=%s, induced %s->%s). %s',
+                metric_name, endpoint_role, hypervisor_ip, final_prom,
+                baseline_prom, baseline_sysfs_val, sysfs_before, final_sysfs,
+                promql)
+            return
+
+        if (sysfs_before is not None and sysfs_after is not None and
+                sysfs_after <= sysfs_before):
+            raise unittest.SkipTest(
+                'Host VF sysfs %s on %s unchanged after drop induce '
+                '(before=%s after=%s). The NIC/driver may not increment VF '
+                'drop stats for this test method.' % (
+                    sysfs_stat_name, hypervisor_ip, sysfs_before,
+                    sysfs_after))
+
+        LOG.warning(
+            'Host VF sysfs %s unavailable around drop induce on %s for '
+            'labels %s (baseline=%s before=%r after=%r, available=%s); '
+            'validating %s via Prometheus delta and metric-storage. %s',
+            sysfs_stat_name, hypervisor_ip, vf_labels, baseline_sysfs,
+            sysfs_before, sysfs_after,
+            self._host_vf_sysfs_stats_available(hypervisor_ip, vf_labels) or
+            'none', metric_name, promql)
+        self._wait_for_vf_prom_and_storage_increase(
+            hypervisor_ip, vf_labels, metric_name, baseline_prom,
+            'drops', min_delta=1, baseline_storage=baseline_storage)
+
+    def _test_vf_counter_increases_with_traffic(
+            self, metric_name, endpoint_role, counter_kind,
+            traffic_generator=None, traffic_packet_count=None):
+        """Validate one net_vf counter increases under VM dataplane traffic."""
+        self._assert_net_vf_metric_reported(metric_name)
+        ctx = self._build_traffic_context()
+        endpoint = ctx[endpoint_role]
+        hypervisor_ip = endpoint['hypervisor_ip']
+        vf_labels = endpoint['vf_labels']
+        sysfs_stat_name = metrics_base.NET_VF_METRIC_TO_SYSFS_STAT.get(
+            metric_name)
+        baseline_sysfs = None
+        use_sysfs = False
+        if sysfs_stat_name:
+            baseline_sysfs = self._host_vf_sysfs_stat(
+                hypervisor_ip, vf_labels, sysfs_stat_name)
+            if baseline_sysfs is not None:
+                use_sysfs = True
+            else:
+                available = self._host_vf_sysfs_stats_available(
+                    hypervisor_ip, vf_labels)
+                LOG.warning(
+                    'Host VF sysfs %s unavailable on %s for labels %s '
+                    '(available: %s); validating %s via Prometheus delta '
+                    'and metric-storage only. Per-VF query: %s',
+                    sysfs_stat_name, hypervisor_ip, vf_labels,
+                    available or 'none', metric_name,
+                    self._vf_promql_filter(hypervisor_ip, vf_labels,
+                                           metric_name))
+        baseline_prom, baseline_storage = (
+            self._wait_for_vf_prom_storage_aligned(
+                hypervisor_ip, vf_labels, metric_name))
+        self.assertIsNotNone(
+            baseline_prom,
+            '%s missing baseline on %s for labels %s' % (
+                metric_name, hypervisor_ip, vf_labels))
+
+        packet_count = traffic_packet_count or self._ping_count()
+        min_packets = self._min_expected_packets_for_count(packet_count)
+        if counter_kind == 'packets':
+            min_delta = min_packets
+        else:
+            min_delta = self._min_expected_bytes_for_count(packet_count)
+        if traffic_generator is None:
+            self._send_ping_packets(
+                ctx['ssh_sender'], ctx['peer_ip'], packet_count, min_packets)
+        else:
+            traffic_generator(ctx, packet_count, min_packets)
+
+        if use_sysfs:
+            self._wait_for_vf_counter_aligned_with_sysfs(
+                hypervisor_ip, vf_labels, metric_name, sysfs_stat_name,
+                baseline_prom, baseline_sysfs, min_delta, min_delta)
+            LOG.warning(
+                '%s increased with sysfs alignment after SR-IOV traffic '
+                '(%s %s)', metric_name, endpoint_role, counter_kind)
+        else:
+            self._wait_for_vf_prom_and_storage_increase(
+                hypervisor_ip, vf_labels, metric_name, baseline_prom,
+                counter_kind, min_delta=min_delta,
+                baseline_storage=baseline_storage)
+            LOG.warning(
+                '%s increased on Prometheus paths after SR-IOV traffic '
+                '(%s %s)', metric_name, endpoint_role, counter_kind)

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/net_vf_metrics_mixin.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/net_vf_metrics_mixin.py
@@ -243,7 +243,10 @@ class NetVfMetricsMixin(object):
         if len(samples) > 1:
             self.fail(
                 '%s in metric-storage on %s matched multiple VF series for '
-                'labels %s' % (metric_name, hypervisor_ip, identity))
+                'labels %s: %s' % (
+                    metric_name, hypervisor_ip, identity,
+                    [s['labels'].get('instance', s['labels'])
+                     for s in samples]))
         return samples[0]['value']
 
     def _vf_promql_filter(self, hypervisor_ip, vf_labels, metric_name):

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
@@ -108,26 +108,6 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         return (self._min_expected_packets() *
                 CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
 
-    def _assert_ovs_interface_metric_reported(self, metric_name):
-        """Assert metric on openstack metric show, compute :9105, metric-storage."""
-        stdout, stderr, returncode = self._metric_show(metric_name)
-        stdout = stdout or ''
-        if self._metric_show_output_usable(metric_name, stdout):
-            LOG.info(
-                "Metric '%s' reported via openstack metric show or "
-                "metric-storage fallback", metric_name)
-        else:
-            LOG.warning(
-                "openstack metric show unavailable for '%s' (exit %s: %s); "
-                "falling back to compute :9105 SSH scrape",
-                metric_name, returncode, stderr)
-            self._assert_metric_on_compute_scrape(metric_name)
-        storage_samples, query_error = self._metric_storage_samples(metric_name)
-        self.assertNotEmpty(
-            storage_samples,
-            '%s missing from metric-storage Prometheus (query: %s)' % (
-                metric_name, query_error))
-
     def _populate_provider_networks(self, servers):
         """Attach provider network metadata used to find peer IPs."""
         for server in servers:

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
@@ -208,7 +208,10 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         if len(samples) > 1:
             self.fail(
                 '%s in metric-storage on %s matched multiple series for '
-                'interface %s' % (metric_name, hypervisor_ip, interface))
+                'interface %s: %s' % (
+                    metric_name, hypervisor_ip, interface,
+                    [s['labels'].get('instance', s['labels'])
+                     for s in samples]))
         return samples[0]['value']
 
     def _assert_counters_match_ovs(self, hypervisor_ip, interface, ovs_stats):

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 import time
+import unittest
 
 from tempest import config
 
@@ -31,6 +32,68 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
     """Verify ovs_interface rx/tx packet and byte counters with VM traffic."""
 
     TEST_NAME = 'network_exporter_generic_traffic'
+
+    def _ensure_test_setup(self):
+        """Default test config when tests-setup omits this test name."""
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_generic_traffic_test_networks(self, test_networks):
+        """Keep mgmt + normal OVS dataplane networks; skip direct SR-IOV ports."""
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('port_type') == 'direct':
+                continue
+            filtered.append(network)
+        if not any(not net.get('mgmt') for net in filtered):
+            raise unittest.SkipTest(
+                'No shared normal provider test-network in tempest_config.yml '
+                'for %s. Add a test-network with port_type: normal (e.g. '
+                'tag: external) in addition to mgmt.' % self.TEST_NAME)
+        LOG.warning(
+            'Generic traffic metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_generic_traffic_boot_kwargs(self):
+        """Boot kwargs: mgmt router only, normal + external ports for dataplane."""
+        ports_filter = 'external,normal'
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _boot_generic_traffic_vms(self):
+        """Create networks, ports, and boot two VMs for dataplane traffic."""
+        self._ensure_test_setup()
+        boot_kwargs = self._build_generic_traffic_boot_kwargs()
+        LOG.warning(
+            'Booting VMs for %s with ports_filter=%s mgmt_subnet_only=True',
+            self.TEST_NAME, boot_kwargs['srv_details'][0]['ports_filter'])
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = (
+            self._filter_generic_traffic_test_networks(full_test_networks))
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
 
     def _traffic_ping_count(self):
         return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
@@ -260,8 +323,7 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
 
     def test_ovs_interface_rx_tx_counters_with_vm_traffic(self):
         """Boot two VMs, send ICMP traffic, verify interface rx/tx metrics."""
-        servers, key_pair = self.create_and_verify_resources(
-            test=self.TEST_NAME, num_servers=2)
+        servers, key_pair = self._boot_generic_traffic_vms()
         self.assertEqual(2, len(servers),
                          'Test requires exactly two VMs')
 

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+OVS_INTERFACE_STAT_KEYS = tuple(metrics_base.OVS_INTERFACE_STAT_TO_METRIC.keys())
+
+
+class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovs_interface rx/tx packet and byte counters with VM traffic."""
+
+    TEST_NAME = 'network_exporter_generic_traffic'
+
+    def _traffic_ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+
+    def _min_expected_packets(self):
+        count = self._traffic_ping_count()
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _min_expected_bytes(self):
+        return (self._min_expected_packets() *
+                CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
+
+    def _assert_ovs_interface_metric_reported(self, metric_name):
+        """Assert metric on openstack metric show, compute :9105, metric-storage."""
+        self._assert_metric_reported(metric_name)
+        storage_samples, query_error = self._metric_storage_samples(metric_name)
+        self.assertNotEmpty(
+            storage_samples,
+            '%s missing from metric-storage Prometheus (query: %s)' % (
+                metric_name, query_error))
+
+    def _populate_provider_networks(self, servers):
+        """Attach provider network metadata used to find peer IPs."""
+        for server in servers:
+            server['provider_networks'] = server.get('trunk_networks', [])
+            server['provider_networks'] += server.get('transparent_networks', [])
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server['id'])['ports']
+            for port in ports:
+                if not port.get('fixed_ips'):
+                    continue
+                provider_dict = {
+                    'network_id': port['network_id'],
+                    'mac_address': port['mac_address'],
+                    'ip_address': port['fixed_ips'][0]['ip_address'],
+                    'port_id': port['id'],
+                }
+                network = [val for val in self.test_network_dict.values()
+                           if port['network_id'] in val['net-id']]
+                if len(network) == 1:
+                    provider_dict['provider:network_type'] = \
+                        network[0]['provider:network_type']
+                server['provider_networks'].append(provider_dict)
+                if self.external_resources_data is not None:
+                    server = self.map_external_provider_network_types(server)
+
+    def _dataplane_peer_ip(self, sender, receiver):
+        """Return receiver data-plane IP on a network shared with sender."""
+        for recv_net in receiver['provider_networks']:
+            for send_net in sender['provider_networks']:
+                if recv_net['network_id'] == send_net['network_id']:
+                    return recv_net['ip_address']
+        self.fail(
+            'No shared provider network between VMs %s and %s; cannot '
+            'send dataplane traffic. Configure test-networks with a common '
+            'provider net and enable provider connectivity.' % (
+                sender.get('name', sender['id']),
+                receiver.get('name', receiver['id'])))
+
+    def _resolve_ovs_interface(self, server):
+        """Return OVS interface name for the VM dataplane port."""
+        if server.get('other_port'):
+            return server['other_port']
+        for net in server['provider_networks']:
+            port_id = net.get('port_id')
+            if not port_id:
+                continue
+            cmd = (
+                'sudo ovs-vsctl --bare --columns=name find Interface '
+                'external-ids:iface-id=%s 2>/dev/null' % port_id)
+            out = self._ssh_run_on_hypervisor(
+                server['hypervisor_ip'], cmd).strip()
+            if out:
+                return out.strip('"')
+        self.fail(
+            'Could not resolve OVS interface for VM %s on %s' % (
+                server.get('name', server['id']), server['hypervisor_ip']))
+
+    def _ovs_interface_stats(self, hypervisor_ip, interface):
+        stats = self.get_ovs_interface_statistics(
+            [interface], hypervisor=hypervisor_ip)
+        return stats[interface]
+
+    def _storage_counter_value(self, hypervisor_ip, metric_name, interface):
+        """Read one ovs_interface counter from metric-storage."""
+        samples, query_error = self._metric_storage_samples(
+            metric_name, hypervisor_ip=hypervisor_ip,
+            required_labels={'interface': interface})
+        if not samples:
+            LOG.warning(
+                'No metric-storage sample for %s on %s interface %s: %s',
+                metric_name, hypervisor_ip, interface, query_error)
+            return None
+        if len(samples) > 1:
+            self.fail(
+                '%s in metric-storage on %s matched multiple series for '
+                'interface %s' % (metric_name, hypervisor_ip, interface))
+        return samples[0]['value']
+
+    def _assert_counters_match_ovs(self, hypervisor_ip, interface, ovs_stats,
+                                   metric_stdout_cache):
+        """Assert openstack metric show, :9105, and metric-storage match OVS."""
+        labels = {'interface': interface}
+        for stat_key, metric_name in (
+                metrics_base.OVS_INTERFACE_STAT_TO_METRIC.items()):
+            ovs_value = int(ovs_stats[stat_key])
+            if metric_name not in metric_stdout_cache:
+                metric_stdout_cache[metric_name], _, _ = self._metric_show(
+                    metric_name)
+            reported = self._parse_compute_metric_show_value(
+                metric_stdout_cache[metric_name], metric_name,
+                hypervisor_ip, row_contains=interface)
+            prom = self._prom_compute_metric_value(
+                hypervisor_ip, metric_name, labels)
+            storage = self._storage_counter_value(
+                hypervisor_ip, metric_name, interface)
+            self.assertIsNotNone(
+                reported,
+                '%s missing row for %s on %s in openstack metric show' % (
+                    metric_name, interface, hypervisor_ip))
+            self.assertIsNotNone(
+                prom,
+                '%s missing on :9105 for %s on %s' % (
+                    metric_name, interface, hypervisor_ip))
+            self.assertIsNotNone(
+                storage,
+                '%s missing in metric-storage for %s on %s' % (
+                    metric_name, interface, hypervisor_ip))
+            self.assertEqual(
+                ovs_value, reported,
+                '%s openstack metric show=%s OVS=%s for %s on %s' % (
+                    metric_name, reported, ovs_value, interface, hypervisor_ip))
+            self.assertEqual(
+                ovs_value, prom,
+                '%s prom=%s OVS=%s for %s on %s' % (
+                    metric_name, prom, ovs_value, interface, hypervisor_ip))
+            self.assertEqual(
+                ovs_value, storage,
+                '%s metric-storage=%s OVS=%s for %s on %s' % (
+                    metric_name, storage, ovs_value, interface, hypervisor_ip))
+
+    def _wait_for_traffic_counters(
+            self, sender, receiver, sender_iface, receiver_iface,
+            baseline_sender, baseline_receiver):
+        """Wait until OVS and exporter counters reflect the ping run."""
+        min_packets = self._min_expected_packets()
+        min_bytes = self._min_expected_bytes()
+        metric_stdout_cache = {}
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            sender_stats = self._ovs_interface_stats(
+                sender['hypervisor_ip'], sender_iface)
+            receiver_stats = self._ovs_interface_stats(
+                receiver['hypervisor_ip'], receiver_iface)
+            sender_delta = {
+                key: int(sender_stats[key]) - int(baseline_sender[key])
+                for key in OVS_INTERFACE_STAT_KEYS}
+            receiver_delta = {
+                key: int(receiver_stats[key]) - int(baseline_receiver[key])
+                for key in OVS_INTERFACE_STAT_KEYS}
+            last = {
+                'sender_delta': sender_delta,
+                'receiver_delta': receiver_delta,
+            }
+            try:
+                self.assertGreaterEqual(
+                    sender_delta['tx_packets'], min_packets,
+                    'sender tx_packets delta %s' % sender_delta)
+                self.assertGreaterEqual(
+                    receiver_delta['rx_packets'], min_packets,
+                    'receiver rx_packets delta %s' % receiver_delta)
+                self.assertGreaterEqual(
+                    sender_delta['tx_bytes'], min_bytes,
+                    'sender tx_bytes delta %s' % sender_delta)
+                self.assertGreaterEqual(
+                    receiver_delta['rx_bytes'], min_bytes,
+                    'receiver rx_bytes delta %s' % receiver_delta)
+                self._assert_counters_match_ovs(
+                    sender['hypervisor_ip'], sender_iface, sender_stats,
+                    metric_stdout_cache)
+                self._assert_counters_match_ovs(
+                    receiver['hypervisor_ip'], receiver_iface, receiver_stats,
+                    metric_stdout_cache)
+                LOG.warning(
+                    'Interface counters consistent after traffic '
+                    '(attempt %s): %s', attempt + 1, last)
+                return sender_delta, receiver_delta
+            except Exception as exc:
+                LOG.warning(
+                    'Attempt %s/%s waiting for traffic counters: %s; last %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for ovs_interface_rx/tx_packets/bytes to '
+            'reflect >=%s packets (%s%% tolerance) between VMs. Last %s' % (
+                min_packets,
+                CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct,
+                last))
+
+    # --- Presence: one Tempest result per ovs_interface counter metric ---
+
+    def test_ovs_interface_rx_packets_reported(self):
+        """Verify ovs_interface_rx_packets on compute and metric-storage."""
+        self._assert_ovs_interface_metric_reported(
+            metrics_base.OVS_INTERFACE_RX_PACKETS_METRIC)
+
+    def test_ovs_interface_tx_packets_reported(self):
+        """Verify ovs_interface_tx_packets on compute and metric-storage."""
+        self._assert_ovs_interface_metric_reported(
+            metrics_base.OVS_INTERFACE_TX_PACKETS_METRIC)
+
+    def test_ovs_interface_rx_bytes_reported(self):
+        """Verify ovs_interface_rx_bytes on compute and metric-storage."""
+        self._assert_ovs_interface_metric_reported(
+            metrics_base.OVS_INTERFACE_RX_BYTES_METRIC)
+
+    def test_ovs_interface_tx_bytes_reported(self):
+        """Verify ovs_interface_tx_bytes on compute and metric-storage."""
+        self._assert_ovs_interface_metric_reported(
+            metrics_base.OVS_INTERFACE_TX_BYTES_METRIC)
+
+    # --- Traffic: one Tempest result for all four counters ---
+
+    def test_ovs_interface_rx_tx_counters_with_vm_traffic(self):
+        """Boot two VMs, send ICMP traffic, verify interface rx/tx metrics."""
+        servers, key_pair = self.create_and_verify_resources(
+            test=self.TEST_NAME, num_servers=2)
+        self.assertEqual(2, len(servers),
+                         'Test requires exactly two VMs')
+
+        if not servers[0].get('provider_networks'):
+            if self.test_all_provider_networks and servers[0].get('fip'):
+                self.verify_provider_networks(servers, key_pair)
+            else:
+                self._populate_provider_networks(servers)
+        try:
+            self.get_ovs_port_names(servers)
+        except (KeyError, TypeError) as exc:
+            LOG.warning(
+                'get_ovs_port_names failed (%s); resolving iface-id on OVS',
+                exc)
+
+        sender, receiver = servers[0], servers[1]
+        peer_ip = self._dataplane_peer_ip(sender, receiver)
+        sender_iface = self._resolve_ovs_interface(sender)
+        receiver_iface = self._resolve_ovs_interface(receiver)
+
+        LOG.warning(
+            'Traffic test: %s (%s:%s) -> %s (%s:%s) peer %s, ping count %s',
+            sender.get('name', sender['id']), sender['hypervisor_ip'],
+            sender_iface, receiver.get('name', receiver['id']),
+            receiver['hypervisor_ip'], receiver_iface, peer_ip,
+            self._traffic_ping_count())
+
+        baseline_sender = self._ovs_interface_stats(
+            sender['hypervisor_ip'], sender_iface)
+        baseline_receiver = self._ovs_interface_stats(
+            receiver['hypervisor_ip'], receiver_iface)
+
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        self._send_ping_packets(
+            ssh_sender, peer_ip, self._traffic_ping_count(),
+            self._min_expected_packets())
+
+        sender_delta, receiver_delta = self._wait_for_traffic_counters(
+            sender, receiver, sender_iface, receiver_iface,
+            baseline_sender, baseline_receiver)
+
+        LOG.warning(
+            'Traffic counters OK: sender tx_packets +%s rx_packets +%s; '
+            'receiver rx_packets +%s tx_packets +%s',
+            sender_delta['tx_packets'], sender_delta['rx_packets'],
+            receiver_delta['rx_packets'], receiver_delta['tx_packets'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
@@ -231,27 +231,21 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                 'interface %s' % (metric_name, hypervisor_ip, interface))
         return samples[0]['value']
 
-    def _assert_counters_match_ovs(self, hypervisor_ip, interface, ovs_stats,
-                                   metric_stdout_cache):
-        """Assert openstack metric show, :9105, and metric-storage match OVS."""
+    def _assert_counters_match_ovs(self, hypervisor_ip, interface, ovs_stats):
+        """Assert compute :9105 and metric-storage match OVS Interface stats.
+
+        openstack metric show is not checked per-interface: VM vhostuser ports
+        (e.g. vhu*) are not broken out in gnocchi rows the way ephemeral test
+        veths are in gauge tests.
+        """
         labels = {'interface': interface}
         for stat_key, metric_name in (
                 metrics_base.OVS_INTERFACE_STAT_TO_METRIC.items()):
             ovs_value = int(ovs_stats[stat_key])
-            if metric_name not in metric_stdout_cache:
-                metric_stdout_cache[metric_name], _, _ = self._metric_show(
-                    metric_name)
-            reported = self._parse_compute_metric_show_value(
-                metric_stdout_cache[metric_name], metric_name,
-                hypervisor_ip, row_contains=interface)
             prom = self._prom_compute_metric_value(
                 hypervisor_ip, metric_name, labels)
             storage = self._storage_counter_value(
                 hypervisor_ip, metric_name, interface)
-            self.assertIsNotNone(
-                reported,
-                '%s missing row for %s on %s in openstack metric show' % (
-                    metric_name, interface, hypervisor_ip))
             self.assertIsNotNone(
                 prom,
                 '%s missing on :9105 for %s on %s' % (
@@ -261,12 +255,8 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                 '%s missing in metric-storage for %s on %s' % (
                     metric_name, interface, hypervisor_ip))
             self.assertEqual(
-                ovs_value, reported,
-                '%s openstack metric show=%s OVS=%s for %s on %s' % (
-                    metric_name, reported, ovs_value, interface, hypervisor_ip))
-            self.assertEqual(
                 ovs_value, prom,
-                '%s prom=%s OVS=%s for %s on %s' % (
+                '%s :9105=%s OVS=%s for %s on %s' % (
                     metric_name, prom, ovs_value, interface, hypervisor_ip))
             self.assertEqual(
                 ovs_value, storage,
@@ -279,7 +269,6 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         """Wait until OVS and exporter counters reflect the ping run."""
         min_packets = self._min_expected_packets()
         min_bytes = self._min_expected_bytes()
-        metric_stdout_cache = {}
         last = {}
         last_exc = None
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
@@ -311,11 +300,9 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                     receiver_delta['rx_bytes'], min_bytes,
                     'receiver rx_bytes delta %s' % receiver_delta)
                 self._assert_counters_match_ovs(
-                    sender['hypervisor_ip'], sender_iface, sender_stats,
-                    metric_stdout_cache)
+                    sender['hypervisor_ip'], sender_iface, sender_stats)
                 self._assert_counters_match_ovs(
-                    receiver['hypervisor_ip'], receiver_iface, receiver_stats,
-                    metric_stdout_cache)
+                    receiver['hypervisor_ip'], receiver_iface, receiver_stats)
                 LOG.warning(
                     'Interface counters consistent after traffic '
                     '(attempt %s): %s', attempt + 1, last)
@@ -329,8 +316,8 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
             if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
                 time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
         self.fail(
-            'Timed out waiting for OVS vs openstack metric show vs :9105 vs '
-            'metric-storage alignment after traffic (packet deltas were %s). '
+            'Timed out waiting for OVS vs :9105 vs metric-storage alignment '
+            'after traffic (packet deltas were %s). '
             'Last alignment error: %s' % (last, last_exc))
 
     # --- Presence: one Tempest result per ovs_interface counter metric ---

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_generic_traffic_metrics.py
@@ -110,7 +110,18 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
 
     def _assert_ovs_interface_metric_reported(self, metric_name):
         """Assert metric on openstack metric show, compute :9105, metric-storage."""
-        self._assert_metric_reported(metric_name)
+        stdout, stderr, returncode = self._metric_show(metric_name)
+        stdout = stdout or ''
+        if self._metric_show_output_usable(metric_name, stdout):
+            LOG.info(
+                "Metric '%s' reported via openstack metric show or "
+                "metric-storage fallback", metric_name)
+        else:
+            LOG.warning(
+                "openstack metric show unavailable for '%s' (exit %s: %s); "
+                "falling back to compute :9105 SSH scrape",
+                metric_name, returncode, stderr)
+            self._assert_metric_on_compute_scrape(metric_name)
         storage_samples, query_error = self._metric_storage_samples(metric_name)
         self.assertNotEmpty(
             storage_samples,
@@ -142,24 +153,49 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                 if self.external_resources_data is not None:
                     server = self.map_external_provider_network_types(server)
 
+    def _mgmt_network_id(self):
+        mgmt_name = getattr(self, 'mgmt_network', None)
+        if not mgmt_name:
+            return None
+        return self.test_network_dict.get(mgmt_name, {}).get('net-id')
+
     def _dataplane_peer_ip(self, sender, receiver):
         """Return receiver data-plane IP on a network shared with sender."""
+        mgmt_net_id = self._mgmt_network_id()
+        shared = []
         for recv_net in receiver['provider_networks']:
             for send_net in sender['provider_networks']:
                 if recv_net['network_id'] == send_net['network_id']:
-                    return recv_net['ip_address']
-        self.fail(
-            'No shared provider network between VMs %s and %s; cannot '
-            'send dataplane traffic. Configure test-networks with a common '
-            'provider net and enable provider connectivity.' % (
-                sender.get('name', sender['id']),
-                receiver.get('name', receiver['id'])))
+                    shared.append(recv_net)
+                    break
+        if not shared:
+            self.fail(
+                'No shared provider network between VMs %s and %s; cannot '
+                'send dataplane traffic. Configure test-networks with a common '
+                'provider net and enable provider connectivity.' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        for net in shared:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net['ip_address']
+        return shared[0]['ip_address']
 
     def _resolve_ovs_interface(self, server):
         """Return OVS interface name for the VM dataplane port."""
         if server.get('other_port'):
             return server['other_port']
-        for net in server['provider_networks']:
+        mgmt_net_id = self._mgmt_network_id()
+        provider_networks = list(server.get('provider_networks', []))
+        if mgmt_net_id:
+            dataplane = [
+                net for net in provider_networks
+                if net.get('network_id') != mgmt_net_id]
+            if dataplane:
+                provider_networks = dataplane + [
+                    net for net in provider_networks
+                    if net.get('network_id') == mgmt_net_id]
+        for net in provider_networks:
             port_id = net.get('port_id')
             if not port_id:
                 continue
@@ -245,6 +281,7 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         min_bytes = self._min_expected_bytes()
         metric_stdout_cache = {}
         last = {}
+        last_exc = None
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
             sender_stats = self._ovs_interface_stats(
                 sender['hypervisor_ip'], sender_iface)
@@ -284,6 +321,7 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                     '(attempt %s): %s', attempt + 1, last)
                 return sender_delta, receiver_delta
             except Exception as exc:
+                last_exc = exc
                 LOG.warning(
                     'Attempt %s/%s waiting for traffic counters: %s; last %s',
                     attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
@@ -291,11 +329,9 @@ class TestGenericTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
             if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
                 time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
         self.fail(
-            'Timed out waiting for ovs_interface_rx/tx_packets/bytes to '
-            'reflect >=%s packets (%s%% tolerance) between VMs. Last %s' % (
-                min_packets,
-                CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct,
-                last))
+            'Timed out waiting for OVS vs openstack metric show vs :9105 vs '
+            'metric-storage alignment after traffic (packet deltas were %s). '
+            'Last alignment error: %s' % (last, last_exc))
 
     # --- Presence: one Tempest result per ovs_interface counter metric ---
 

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_config_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_config_metrics.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+OVNC_ENCAP_IP_METRIC = metrics_base.OVNC_ENCAP_IP_METRIC
+OVNC_ENCAP_TYPE_METRIC = metrics_base.OVNC_ENCAP_TYPE_METRIC
+OVNC_SB_CONNECTION_METHOD_METRIC = (
+    metrics_base.OVNC_SB_CONNECTION_METHOD_METRIC)
+OVNC_MONITOR_ALL_METRIC = metrics_base.OVNC_MONITOR_ALL_METRIC
+OVNC_BRIDGE_MAPPINGS_METRIC = metrics_base.OVNC_BRIDGE_MAPPINGS_METRIC
+
+
+class TestOvncConfigMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovnc_* config gauges against ovs-vsctl external_ids (Suite 7.1)."""
+
+    def test_ovnc_encap_ip_reported(self):
+        """Verify ovnc_encap_ip on OVN :1981 and metric-storage."""
+        self._assert_ovnc_config_metric_reported(OVNC_ENCAP_IP_METRIC)
+
+    def test_ovnc_encap_type_reported(self):
+        """Verify ovnc_encap_type on OVN :1981 and metric-storage."""
+        self._assert_ovnc_config_metric_reported(OVNC_ENCAP_TYPE_METRIC)
+
+    def test_ovnc_sb_connection_method_reported(self):
+        """Verify ovnc_sb_connection_method on OVN :1981 and metric-storage."""
+        self._assert_ovnc_config_metric_reported(
+            OVNC_SB_CONNECTION_METHOD_METRIC)
+
+    def test_ovnc_monitor_all_reported(self):
+        """Verify ovnc_monitor_all on OVN :1981 and metric-storage."""
+        self._assert_ovnc_config_metric_reported(OVNC_MONITOR_ALL_METRIC)
+
+    def test_ovnc_bridge_mappings_reported(self):
+        """Verify ovnc_bridge_mappings on OVN :1981 and metric-storage."""
+        self._assert_ovnc_config_metric_reported(OVNC_BRIDGE_MAPPINGS_METRIC)

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -105,7 +105,10 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         configured = int(count * (100 - tolerance) / 100)
         floor = CONF.nfv_plugin_options.network_exporter_router_traffic_min_packets
         if transmitted:
-            scaled = max(floor, int(transmitted * 0.35))
+            scale_pct = (
+                CONF.nfv_plugin_options.
+                network_exporter_router_traffic_metric_scale_pct)
+            scaled = max(floor, int(transmitted * scale_pct / 100))
             return min(configured, scaled)
         return max(floor, configured)
 

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -44,7 +44,12 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         for network in test_networks:
             if network.get('port_type') == 'direct':
                 continue
-            filtered.append(network)
+            net = dict(network)
+            # Attach the ICMP-capable security group to every router-test port,
+            # not only mgmt (dataplane ports otherwise keep the default SG).
+            if net.get('sec_groups') is not False:
+                net['sec_groups'] = True
+            filtered.append(net)
         non_mgmt = [net for net in filtered if not net.get('mgmt')]
         if len(non_mgmt) < 1:
             raise unittest.SkipTest(
@@ -196,70 +201,67 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         scored.sort(key=lambda item: item[0])
         return [(bind_ip, peer_ip) for _, bind_ip, peer_ip in scored]
 
-    def _validated_cross_subnet_pairs(self, ssh_sender, sender, receiver):
-        """Return probe-verified (bind_ip, peer_ip) pairs that use the router."""
-        validated = []
+    def _router_traffic_endpoints(self, ssh_sender, ssh_receiver, sender,
+                                  receiver):
+        """Return ordered (ssh, bind_ip, peer_ip) triples for router traffic."""
+        probed = []
+        fallback = []
+        seen = set()
         for bind_ip, peer_ip in self._cross_subnet_peer_candidates(
                 sender, receiver):
-            LOG.warning(
-                'Probing cross-subnet pair bind %s -> %s', bind_ip, peer_ip)
-            if self._probe_bound_ping(ssh_sender, bind_ip, peer_ip):
+            forward = (bind_ip, peer_ip)
+            reverse = (peer_ip, bind_ip)
+            if forward not in seen:
                 LOG.warning(
-                    'Probe OK for cross-subnet pair bind %s -> %s',
-                    bind_ip, peer_ip)
-                validated.append((bind_ip, peer_ip))
-        return validated
+                    'Probing cross-subnet pair bind %s -> %s', bind_ip, peer_ip)
+                if self._probe_bound_ping(ssh_sender, bind_ip, peer_ip):
+                    LOG.warning('Probe OK (sender) %s -> %s', bind_ip, peer_ip)
+                    probed.append((ssh_sender, bind_ip, peer_ip))
+                    seen.add(forward)
+                    continue
+                if self._probe_bound_ping(ssh_receiver, peer_ip, bind_ip):
+                    LOG.warning(
+                        'Probe OK (receiver) %s -> %s', peer_ip, bind_ip)
+                    probed.append((ssh_receiver, peer_ip, bind_ip))
+                    seen.add(reverse)
+                    continue
+                fallback.append((ssh_sender, bind_ip, peer_ip))
+                seen.add(forward)
+        if probed:
+            return probed + [
+                ep for ep in fallback
+                if (ep[1], ep[2]) not in {(p[1], p[2]) for p in probed}]
+        if fallback:
+            LOG.warning(
+                'No cross-subnet ICMP probe succeeded; using ranked '
+                'candidates (ensure sec_groups on all router test-networks)')
+            return fallback
+        return []
 
-    def _select_cross_subnet_pair(self, ssh_sender, sender, receiver):
-        """Pick a routable cross-subnet IP pair, probing with bound ICMP."""
-        validated = self._validated_cross_subnet_pairs(
-            ssh_sender, sender, receiver)
-        if not validated:
-            self.fail(
-                'No cross-subnet ICMP probe succeeded between VMs %s and %s. '
-                'Ensure mgmt and at least one other routed network, security '
-                'groups allow ICMP, and VMs have ports on both subnets.' % (
-                    sender.get('name', sender['id']),
-                    receiver.get('name', receiver['id'])))
-        bind_ip, peer_ip = validated[0]
-        LOG.warning(
-            'Using routable cross-subnet pair bind %s -> %s',
-            bind_ip, peer_ip)
-        return bind_ip, peer_ip
-
-    def _send_router_cross_subnet_traffic(self, ssh_sender, sender, receiver,
-                                          packet_count, preferred_pair=None):
+    def _send_router_cross_subnet_traffic(self, endpoints, packet_count):
         """Generate L3 ICMP through the Neutron router for port counter tests."""
-        validated = self._validated_cross_subnet_pairs(
-            ssh_sender, sender, receiver)
-        if not validated:
-            self.fail(
-                'No cross-subnet ICMP probe succeeded between VMs %s and %s' % (
-                    sender.get('name', sender['id']),
-                    receiver.get('name', receiver['id'])))
-        if preferred_pair and preferred_pair in validated:
-            validated.remove(preferred_pair)
-            validated.insert(0, preferred_pair)
+        if not endpoints:
+            self.fail('No cross-subnet traffic endpoints between VMs')
         last_err = None
-        for bind_ip, peer_ip in validated:
+        for ssh, bind_ip, peer_ip in endpoints:
             LOG.warning(
                 'Sending %d bound ICMP (xmit-only) from %s to %s',
                 packet_count, bind_ip, peer_ip)
             try:
                 total_xmit = self._send_ping_packets_bound(
-                    ssh_sender, bind_ip, peer_ip, packet_count,
+                    ssh, bind_ip, peer_ip, packet_count,
                     min_packets=1, accept_xmit_only=True)
                 LOG.warning(
-                    'Transmitted %d ICMP probes on verified pair %s -> %s',
+                    'Transmitted %d ICMP probes on pair %s -> %s',
                     total_xmit, bind_ip, peer_ip)
-                return bind_ip, peer_ip, total_xmit
+                return ssh, bind_ip, peer_ip, total_xmit
             except AssertionError as exc:
                 last_err = exc
                 LOG.warning(
                     'Cross-subnet xmit failed for %s -> %s: %s',
                     bind_ip, peer_ip, exc)
         self.fail(
-            'Probe-verified cross-subnet pairs failed to transmit ICMP: %s' %
+            'All cross-subnet traffic endpoints failed to transmit ICMP: %s' %
             last_err)
 
     def _sample_map_deltas(self, after, before):
@@ -293,7 +295,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
 
     def _wait_for_router_traffic_counters(self, hypervisor_ip, baseline_pkts,
                                           baseline_bytes, min_packets=None,
-                                          min_bytes=None, ssh_sender=None,
+                                          min_bytes=None, ssh_traffic=None,
                                           packet_count=None,
                                           traffic_pair=None):
         min_packets = (min_packets if min_packets is not None else
@@ -303,7 +305,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
-            if (attempt > 0 and ssh_sender is not None and traffic_pair and
+            if (attempt > 0 and ssh_traffic is not None and traffic_pair and
                     packet_count):
                 bind_ip, peer_ip = traffic_pair
                 LOG.warning(
@@ -311,7 +313,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                     attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
                     bind_ip, peer_ip)
                 self._send_ping_packets_bound(
-                    ssh_sender, bind_ip, peer_ip, packet_count,
+                    ssh_traffic, bind_ip, peer_ip, packet_count,
                     min_packets=1, accept_xmit_only=True)
             pkts_after = self._router_port_sample_map(
                 hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
@@ -373,8 +375,15 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         hypervisor_ip = sender['hypervisor_ip']
         ssh_sender = self.get_remote_client(
             sender['fip'], self.instance_user, key_pair['private_key'])
-        bind_ip, peer_ip = self._select_cross_subnet_pair(
-            ssh_sender, sender, receiver)
+        ssh_receiver = self.get_remote_client(
+            receiver['fip'], self.instance_user, key_pair['private_key'])
+        endpoints = self._router_traffic_endpoints(
+            ssh_sender, ssh_receiver, sender, receiver)
+        if not endpoints:
+            self.fail(
+                'No cross-subnet IPs between VMs %s and %s' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
         packet_count = self._traffic_ping_count()
 
         baseline_pkts = self._router_port_sample_map(
@@ -382,9 +391,8 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         baseline_bytes = self._router_port_sample_map(
             hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
 
-        bind_ip, peer_ip, total_xmit = self._send_router_cross_subnet_traffic(
-            ssh_sender, sender, receiver, packet_count,
-            preferred_pair=(bind_ip, peer_ip))
+        ssh_traffic, bind_ip, peer_ip, total_xmit = (
+            self._send_router_cross_subnet_traffic(endpoints, packet_count))
         min_packets = self._min_expected_packets(transmitted=total_xmit)
         min_bytes = self._min_expected_bytes(min_packets)
         LOG.warning(
@@ -396,7 +404,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         result = self._wait_for_router_traffic_counters(
             hypervisor_ip, baseline_pkts, baseline_bytes,
             min_packets=min_packets, min_bytes=min_bytes,
-            ssh_sender=ssh_sender, packet_count=packet_count,
+            ssh_traffic=ssh_traffic, packet_count=packet_count,
             traffic_pair=(bind_ip, peer_ip))
         LOG.warning(
             'Router port traffic OK: pkts total +%s (peak port %s +%s), '

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -175,24 +175,6 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         key = max(deltas, key=deltas.get)
         return key, deltas[key]
 
-    def _assert_router_series_synced(self, hypervisor_ip, metric_name, label_key):
-        prom_map = self._router_port_sample_map(hypervisor_ip, metric_name)
-        storage_map = self._router_port_sample_map(
-            hypervisor_ip, metric_name, storage=True)
-        self.assertIn(
-            label_key, prom_map,
-            '%s series %s missing on OVN :1981 scrape for %s' % (
-                metric_name, label_key, hypervisor_ip))
-        self.assertIn(
-            label_key, storage_map,
-            '%s series %s missing in metric-storage for %s' % (
-                metric_name, label_key, hypervisor_ip))
-        self.assertEqual(
-            prom_map[label_key], storage_map[label_key],
-            '%s OVN :1981=%s metric-storage=%s for %s series %s' % (
-                metric_name, prom_map[label_key], storage_map[label_key],
-                hypervisor_ip, label_key))
-
     def _wait_for_router_traffic_counters(self, hypervisor_ip, baseline_pkts,
                                           baseline_bytes):
         min_packets = self._min_expected_packets()
@@ -222,14 +204,6 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                 self.assertGreaterEqual(
                     bytes_inc, min_bytes,
                     'ovnc_router_port_traffic_bytes delta %s' % last)
-                self._assert_router_series_synced(
-                    hypervisor_ip,
-                    metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC,
-                    pkts_key)
-                self._assert_router_series_synced(
-                    hypervisor_ip,
-                    metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC,
-                    bytes_key)
                 LOG.warning(
                     'Router port counters increased (attempt %s): %s',
                     attempt + 1, last)
@@ -249,12 +223,12 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
     # --- Presence ---
 
     def test_ovnc_router_port_traffic_pkts_reported(self):
-        """Verify ovnc_router_port_traffic_pkts on OVN :1981 and metric-storage."""
+        """Verify ovnc_router_port_traffic_pkts in metric-storage."""
         self._assert_router_port_metric_reported(
             metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
 
     def test_ovnc_router_port_traffic_bytes_reported(self):
-        """Verify ovnc_router_port_traffic_bytes on OVN :1981 and metric-storage."""
+        """Verify ovnc_router_port_traffic_bytes in metric-storage."""
         self._assert_router_port_metric_reported(
             metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
 

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovnc_router_port_traffic_* counters with cross-subnet VM traffic."""
+
+    TEST_NAME = 'network_exporter_router_traffic'
+
+    def _ensure_test_setup(self):
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_router_test_networks(self, test_networks):
+        filtered = []
+        for network in test_networks:
+            if network.get('port_type') == 'direct':
+                continue
+            filtered.append(network)
+        non_mgmt = [net for net in filtered if not net.get('mgmt')]
+        if len(non_mgmt) < 1:
+            raise unittest.SkipTest(
+                'Need mgmt plus at least one normal test-network for %s' %
+                self.TEST_NAME)
+        cidrs = {net.get('cidr') for net in filtered if net.get('cidr')}
+        if len(cidrs) < 2:
+            raise unittest.SkipTest(
+                'Need at least two test-networks with distinct CIDRs for %s '
+                '(mgmt + one normal net with a different subnet, e.g. vlan1500 '
+                'external plus vlan1600 mgmt).' % self.TEST_NAME)
+        LOG.warning(
+            'Router traffic metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_router_boot_kwargs(self):
+        ports_filter = 'external,normal'
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'test_networks_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _boot_router_traffic_vms(self):
+        self._ensure_test_setup()
+        boot_kwargs = self._build_router_boot_kwargs()
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = self._filter_router_test_networks(
+            full_test_networks)
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _traffic_ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+
+    def _min_expected_packets(self):
+        count = self._traffic_ping_count()
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _min_expected_bytes(self):
+        return (self._min_expected_packets() *
+                CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
+
+    def _populate_provider_networks(self, servers):
+        for server in servers:
+            server['provider_networks'] = server.get('trunk_networks', [])
+            server['provider_networks'] += server.get('transparent_networks', [])
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server['id'])['ports']
+            for port in ports:
+                if not port.get('fixed_ips'):
+                    continue
+                provider_dict = {
+                    'network_id': port['network_id'],
+                    'mac_address': port['mac_address'],
+                    'ip_address': port['fixed_ips'][0]['ip_address'],
+                    'port_id': port['id'],
+                }
+                server['provider_networks'].append(provider_dict)
+
+    def _mgmt_network_id(self):
+        mgmt_name = getattr(self, 'mgmt_network', None)
+        if not mgmt_name:
+            return None
+        return self.test_network_dict.get(mgmt_name, {}).get('net-id')
+
+    def _cross_subnet_peer_ips(self, sender, receiver):
+        """Return (sender_bind_ip, receiver_ip) on different subnets."""
+        mgmt_net_id = self._mgmt_network_id()
+        recv_ip = None
+        for r_net in receiver['provider_networks']:
+            if mgmt_net_id and r_net['network_id'] == mgmt_net_id:
+                recv_ip = r_net['ip_address']
+                break
+        if not recv_ip:
+            recv_ip = receiver['provider_networks'][0]['ip_address']
+        recv_net_id = None
+        for r_net in receiver['provider_networks']:
+            if r_net['ip_address'] == recv_ip:
+                recv_net_id = r_net['network_id']
+                break
+        send_bind_ip = None
+        for s_net in sender['provider_networks']:
+            if recv_net_id and s_net['network_id'] != recv_net_id:
+                send_bind_ip = s_net['ip_address']
+                break
+        if not send_bind_ip:
+            for s_net in sender['provider_networks']:
+                if mgmt_net_id and s_net['network_id'] != mgmt_net_id:
+                    send_bind_ip = s_net['ip_address']
+                    break
+        if not send_bind_ip or not recv_ip:
+            self.fail(
+                'Could not find cross-subnet IPs between VMs %s and %s. '
+                'Ensure mgmt and at least one other routed network.' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        if send_bind_ip.split('.')[:3] == recv_ip.split('.')[:3]:
+            self.fail(
+                'Sender bind %s and receiver %s appear to share a subnet; '
+                'router traffic test requires different subnets.' % (
+                    send_bind_ip, recv_ip))
+        return send_bind_ip, recv_ip
+
+    def _sample_map_deltas(self, after, before):
+        deltas = {}
+        for key, value in after.items():
+            deltas[key] = value - before.get(key, 0)
+        return deltas
+
+    def _best_delta_key(self, deltas):
+        if not deltas:
+            return None, 0
+        key = max(deltas, key=deltas.get)
+        return key, deltas[key]
+
+    def _assert_router_series_synced(self, hypervisor_ip, metric_name, label_key):
+        prom_map = self._router_port_sample_map(hypervisor_ip, metric_name)
+        storage_map = self._router_port_sample_map(
+            hypervisor_ip, metric_name, storage=True)
+        self.assertIn(
+            label_key, prom_map,
+            '%s series %s missing on :9105 for %s' % (
+                metric_name, label_key, hypervisor_ip))
+        self.assertIn(
+            label_key, storage_map,
+            '%s series %s missing in metric-storage for %s' % (
+                metric_name, label_key, hypervisor_ip))
+        self.assertEqual(
+            prom_map[label_key], storage_map[label_key],
+            '%s :9105=%s metric-storage=%s for %s series %s' % (
+                metric_name, prom_map[label_key], storage_map[label_key],
+                hypervisor_ip, label_key))
+
+    def _wait_for_router_traffic_counters(self, hypervisor_ip, baseline_pkts,
+                                          baseline_bytes):
+        min_packets = self._min_expected_packets()
+        min_bytes = self._min_expected_bytes()
+        last_exc = None
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            pkts_after = self._router_port_sample_map(
+                hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
+            bytes_after = self._router_port_sample_map(
+                hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
+            pkts_delta = self._sample_map_deltas(pkts_after, baseline_pkts)
+            bytes_delta = self._sample_map_deltas(bytes_after, baseline_bytes)
+            pkts_key, pkts_inc = self._best_delta_key(pkts_delta)
+            bytes_key, bytes_inc = self._best_delta_key(bytes_delta)
+            last = {
+                'pkts_key': pkts_key,
+                'pkts_delta': pkts_inc,
+                'bytes_key': bytes_key,
+                'bytes_delta': bytes_inc,
+            }
+            try:
+                self.assertIsNotNone(pkts_key)
+                self.assertGreaterEqual(
+                    pkts_inc, min_packets,
+                    'ovnc_router_port_traffic_pkts delta %s' % last)
+                self.assertGreaterEqual(
+                    bytes_inc, min_bytes,
+                    'ovnc_router_port_traffic_bytes delta %s' % last)
+                self._assert_router_series_synced(
+                    hypervisor_ip,
+                    metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC,
+                    pkts_key)
+                self._assert_router_series_synced(
+                    hypervisor_ip,
+                    metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC,
+                    bytes_key)
+                LOG.warning(
+                    'Router port counters increased (attempt %s): %s',
+                    attempt + 1, last)
+                return last
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for router port counters: %s; %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for ovnc_router_port_traffic counters after '
+            'cross-subnet traffic. Last %s; last error: %s' % (last, last_exc))
+
+    # --- Presence ---
+
+    def test_ovnc_router_port_traffic_pkts_reported(self):
+        """Verify ovnc_router_port_traffic_pkts on :9105 and metric-storage."""
+        self._assert_router_port_metric_reported(
+            metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
+
+    def test_ovnc_router_port_traffic_bytes_reported(self):
+        """Verify ovnc_router_port_traffic_bytes on :9105 and metric-storage."""
+        self._assert_router_port_metric_reported(
+            metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
+
+    # --- Traffic ---
+
+    def test_ovnc_router_port_traffic_increments_with_cross_subnet_traffic(self):
+        """Boot two VMs on routed subnets, ping across router, verify counters."""
+        servers, key_pair = self._boot_router_traffic_vms()
+        self.assertEqual(2, len(servers), 'Test requires exactly two VMs')
+        if not servers[0].get('provider_networks'):
+            if self.test_all_provider_networks and servers[0].get('fip'):
+                self.verify_provider_networks(servers, key_pair)
+            else:
+                self._populate_provider_networks(servers)
+
+        sender, receiver = servers[0], servers[1]
+        bind_ip, peer_ip = self._cross_subnet_peer_ips(sender, receiver)
+        hypervisor_ip = sender['hypervisor_ip']
+        LOG.warning(
+            'Router traffic test: %s ping -I %s -> %s (hypervisor %s), count %s',
+            sender.get('name', sender['id']), bind_ip, peer_ip, hypervisor_ip,
+            self._traffic_ping_count())
+
+        baseline_pkts = self._router_port_sample_map(
+            hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
+        baseline_bytes = self._router_port_sample_map(
+            hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
+
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        self._send_ping_packets_bound(
+            ssh_sender, bind_ip, peer_ip, self._traffic_ping_count(),
+            self._min_expected_packets())
+
+        result = self._wait_for_router_traffic_counters(
+            hypervisor_ip, baseline_pkts, baseline_bytes)
+        LOG.warning(
+            'Router port traffic OK: pkts series %s +%s, bytes series %s +%s',
+            result['pkts_key'], result['pkts_delta'],
+            result['bytes_key'], result['bytes_delta'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -181,7 +181,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
             hypervisor_ip, metric_name, storage=True)
         self.assertIn(
             label_key, prom_map,
-            '%s series %s missing on :9105 for %s' % (
+            '%s series %s missing on OVN :1981 scrape for %s' % (
                 metric_name, label_key, hypervisor_ip))
         self.assertIn(
             label_key, storage_map,
@@ -189,7 +189,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                 metric_name, label_key, hypervisor_ip))
         self.assertEqual(
             prom_map[label_key], storage_map[label_key],
-            '%s :9105=%s metric-storage=%s for %s series %s' % (
+            '%s OVN :1981=%s metric-storage=%s for %s series %s' % (
                 metric_name, prom_map[label_key], storage_map[label_key],
                 hypervisor_ip, label_key))
 
@@ -249,12 +249,12 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
     # --- Presence ---
 
     def test_ovnc_router_port_traffic_pkts_reported(self):
-        """Verify ovnc_router_port_traffic_pkts on :9105 and metric-storage."""
+        """Verify ovnc_router_port_traffic_pkts on OVN :1981 and metric-storage."""
         self._assert_router_port_metric_reported(
             metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
 
     def test_ovnc_router_port_traffic_bytes_reported(self):
-        """Verify ovnc_router_port_traffic_bytes on :9105 and metric-storage."""
+        """Verify ovnc_router_port_traffic_bytes on OVN :1981 and metric-storage."""
         self._assert_router_port_metric_reported(
             metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
 

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -102,6 +102,29 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         return (self._min_expected_packets() *
                 CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
 
+    def _slow_ping_cap(self):
+        return min(
+            self._traffic_ping_count(),
+            int(metrics_base.PING_MAX_WALL_SECONDS /
+                metrics_base.PING_SLOW_INTERVAL_SEC))
+
+    def _effective_traffic_expectations(self, ssh_sender):
+        """Return (min_packets, min_bytes) achievable on this guest."""
+        min_packets = self._min_expected_packets()
+        min_bytes = self._min_expected_bytes()
+        if self._guest_has_passwordless_sudo(ssh_sender):
+            return min_packets, min_bytes
+        capped = self._slow_ping_cap()
+        if capped >= min_packets:
+            return min_packets, min_bytes
+        LOG.warning(
+            'No passwordless sudo on sender; expecting >= %d router pkts/bytes '
+            '(slow ping cap %d, configured min pkts %d)',
+            capped, capped, min_packets)
+        return capped, (
+            capped *
+            CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
+
     def _populate_provider_networks(self, servers):
         for server in servers:
             server['provider_networks'] = server.get('trunk_networks', [])
@@ -190,8 +213,25 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         return bind_ip, peer_ip
 
     def _send_router_cross_subnet_traffic(self, ssh_sender, bind_ip, peer_ip,
-                                          packet_count):
-        """Generate L3 traffic through the Neutron router via bound UDP."""
+                                          packet_count, min_packets):
+        """Generate L3 traffic through the Neutron router.
+
+        ovnc_router_port_traffic_* tracks ICMP-sized L3 packets on logical
+        router ports; bound ICMP is the primary generator. UDP is a fallback
+        when ICMP cannot be sent at the required rate.
+        """
+        LOG.warning(
+            'Sending %d bound ICMP echo requests from %s to %s',
+            packet_count, bind_ip, peer_ip)
+        try:
+            self._send_ping_packets_bound(
+                ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
+            return
+        except AssertionError as exc:
+            LOG.warning(
+                'Bound ICMP flood from %s to %s failed (%s); '
+                'falling back to bound UDP',
+                bind_ip, peer_ip, exc)
         LOG.warning(
             'Sending %d bound UDP datagrams from %s to %s',
             packet_count, bind_ip, peer_ip)
@@ -210,9 +250,28 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         key = max(deltas, key=deltas.get)
         return key, deltas[key]
 
+    def _router_port_delta_summary(self, pkts_after, pkts_before,
+                                   bytes_after, bytes_before):
+        pkts_delta = self._sample_map_deltas(pkts_after, pkts_before)
+        bytes_delta = self._sample_map_deltas(bytes_after, bytes_before)
+        pkts_key, pkts_peak = self._best_delta_key(pkts_delta)
+        bytes_key, bytes_peak = self._best_delta_key(bytes_delta)
+        return {
+            'pkts_key': pkts_key,
+            'pkts_delta': sum(pkts_delta.values()),
+            'pkts_peak_delta': pkts_peak,
+            'pkts_by_port': pkts_delta,
+            'bytes_key': bytes_key,
+            'bytes_delta': sum(bytes_delta.values()),
+            'bytes_peak_delta': bytes_peak,
+            'bytes_by_port': bytes_delta,
+        }
+
     def _wait_for_router_traffic_counters(self, hypervisor_ip, baseline_pkts,
                                           baseline_bytes, min_packets=None,
-                                          min_bytes=None):
+                                          min_bytes=None, ssh_sender=None,
+                                          bind_ip=None, peer_ip=None,
+                                          packet_count=None):
         min_packets = (min_packets if min_packets is not None else
                        self._min_expected_packets())
         min_bytes = (min_bytes if min_bytes is not None else
@@ -220,27 +279,28 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            if (attempt > 0 and ssh_sender is not None and bind_ip and
+                    peer_ip and packet_count):
+                LOG.warning(
+                    'Re-sending router traffic (attempt %s/%s)',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS)
+                self._send_router_cross_subnet_traffic(
+                    ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
             pkts_after = self._router_port_sample_map(
                 hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
             bytes_after = self._router_port_sample_map(
                 hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
-            pkts_delta = self._sample_map_deltas(pkts_after, baseline_pkts)
-            bytes_delta = self._sample_map_deltas(bytes_after, baseline_bytes)
-            pkts_key, pkts_inc = self._best_delta_key(pkts_delta)
-            bytes_key, bytes_inc = self._best_delta_key(bytes_delta)
-            last = {
-                'pkts_key': pkts_key,
-                'pkts_delta': pkts_inc,
-                'bytes_key': bytes_key,
-                'bytes_delta': bytes_inc,
-            }
+            last = self._router_port_delta_summary(
+                pkts_after, baseline_pkts, bytes_after, baseline_bytes)
             try:
-                self.assertIsNotNone(pkts_key)
+                self.assertNotEqual(last['pkts_delta'], 0,
+                                    'ovnc_router_port_traffic_pkts delta %s' %
+                                    last)
                 self.assertGreaterEqual(
-                    pkts_inc, min_packets,
+                    last['pkts_delta'], min_packets,
                     'ovnc_router_port_traffic_pkts delta %s' % last)
                 self.assertGreaterEqual(
-                    bytes_inc, min_bytes,
+                    last['bytes_delta'], min_bytes,
                     'ovnc_router_port_traffic_bytes delta %s' % last)
                 LOG.warning(
                     'Router port counters increased (attempt %s): %s',
@@ -289,10 +349,13 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         bind_ip, peer_ip = self._select_cross_subnet_pair(
             ssh_sender, sender, receiver)
         packet_count = self._traffic_ping_count()
+        min_packets, min_bytes = self._effective_traffic_expectations(
+            ssh_sender)
         LOG.warning(
-            'Router traffic test: %s bind %s -> %s (hypervisor %s), count %s',
+            'Router traffic test: %s bind %s -> %s (hypervisor %s), count %s, '
+            'min pkts %s',
             sender.get('name', sender['id']), bind_ip, peer_ip, hypervisor_ip,
-            packet_count)
+            packet_count, min_packets)
 
         baseline_pkts = self._router_port_sample_map(
             hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
@@ -300,11 +363,16 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
             hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
 
         self._send_router_cross_subnet_traffic(
-            ssh_sender, bind_ip, peer_ip, packet_count)
+            ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
 
         result = self._wait_for_router_traffic_counters(
-            hypervisor_ip, baseline_pkts, baseline_bytes)
+            hypervisor_ip, baseline_pkts, baseline_bytes,
+            min_packets=min_packets, min_bytes=min_bytes,
+            ssh_sender=ssh_sender, bind_ip=bind_ip, peer_ip=peer_ip,
+            packet_count=packet_count)
         LOG.warning(
-            'Router port traffic OK: pkts series %s +%s, bytes series %s +%s',
-            result['pkts_key'], result['pkts_delta'],
-            result['bytes_key'], result['bytes_delta'])
+            'Router port traffic OK: pkts total +%s (peak port %s +%s), '
+            'bytes total +%s (peak port %s +%s)',
+            result['pkts_delta'], result['pkts_key'],
+            result['pkts_peak_delta'], result['bytes_delta'],
+            result['bytes_key'], result['bytes_peak_delta'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -92,15 +92,22 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
     def _traffic_ping_count(self):
         return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
 
-    def _min_expected_packets(self):
+    def _min_expected_packets(self, transmitted=None):
         count = self._traffic_ping_count()
         tolerance = (
             CONF.nfv_plugin_options.
             network_exporter_router_traffic_packet_tolerance_pct)
-        return int(count * (100 - tolerance) / 100)
+        configured = int(count * (100 - tolerance) / 100)
+        floor = CONF.nfv_plugin_options.network_exporter_router_traffic_min_packets
+        if transmitted:
+            scaled = max(floor, int(transmitted * 0.35))
+            return min(configured, scaled)
+        return max(floor, configured)
 
-    def _min_expected_bytes(self):
-        return (self._min_expected_packets() *
+    def _min_expected_bytes(self, min_packets=None):
+        min_packets = (min_packets if min_packets is not None else
+                       self._min_expected_packets())
+        return (min_packets *
                 CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
 
     def _slow_ping_cap(self):
@@ -189,67 +196,71 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         scored.sort(key=lambda item: item[0])
         return [(bind_ip, peer_ip) for _, bind_ip, peer_ip in scored]
 
-    def _select_cross_subnet_pair(self, ssh_sender, sender, receiver):
-        """Pick a routable cross-subnet IP pair, probing with bound ICMP."""
-        candidates = self._cross_subnet_peer_candidates(sender, receiver)
-        if not candidates:
-            self.fail(
-                'Could not find cross-subnet IPs between VMs %s and %s. '
-                'Ensure mgmt and at least one other routed network.' % (
-                    sender.get('name', sender['id']),
-                    receiver.get('name', receiver['id'])))
-        for bind_ip, peer_ip in candidates:
+    def _validated_cross_subnet_pairs(self, ssh_sender, sender, receiver):
+        """Return probe-verified (bind_ip, peer_ip) pairs that use the router."""
+        validated = []
+        for bind_ip, peer_ip in self._cross_subnet_peer_candidates(
+                sender, receiver):
             LOG.warning(
                 'Probing cross-subnet pair bind %s -> %s', bind_ip, peer_ip)
             if self._probe_bound_ping(ssh_sender, bind_ip, peer_ip):
                 LOG.warning(
-                    'Using routable cross-subnet pair bind %s -> %s',
+                    'Probe OK for cross-subnet pair bind %s -> %s',
                     bind_ip, peer_ip)
-                return bind_ip, peer_ip
-        bind_ip, peer_ip = candidates[0]
+                validated.append((bind_ip, peer_ip))
+        return validated
+
+    def _select_cross_subnet_pair(self, ssh_sender, sender, receiver):
+        """Pick a routable cross-subnet IP pair, probing with bound ICMP."""
+        validated = self._validated_cross_subnet_pairs(
+            ssh_sender, sender, receiver)
+        if not validated:
+            self.fail(
+                'No cross-subnet ICMP probe succeeded between VMs %s and %s. '
+                'Ensure mgmt and at least one other routed network, security '
+                'groups allow ICMP, and VMs have ports on both subnets.' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        bind_ip, peer_ip = validated[0]
         LOG.warning(
-            'No bound ICMP probe succeeded; using best candidate bind %s -> %s '
-            'with UDP flood only',
+            'Using routable cross-subnet pair bind %s -> %s',
             bind_ip, peer_ip)
         return bind_ip, peer_ip
 
     def _send_router_cross_subnet_traffic(self, ssh_sender, sender, receiver,
-                                          packet_count, min_packets,
-                                          preferred_pair=None):
-        """Generate L3 ICMP through the Neutron router for port counter tests.
-
-        Router port counters reflect forwarded probes; ICMP replies are not
-        required. Try each cross-subnet bind/peer pair until one transmits.
-        """
-        candidates = self._cross_subnet_peer_candidates(sender, receiver)
-        if preferred_pair and preferred_pair in candidates:
-            candidates.remove(preferred_pair)
-            candidates.insert(0, preferred_pair)
-        elif preferred_pair:
-            candidates.insert(0, preferred_pair)
-        if not candidates:
+                                          packet_count, preferred_pair=None):
+        """Generate L3 ICMP through the Neutron router for port counter tests."""
+        validated = self._validated_cross_subnet_pairs(
+            ssh_sender, sender, receiver)
+        if not validated:
             self.fail(
-                'Could not find cross-subnet IPs between VMs %s and %s' % (
+                'No cross-subnet ICMP probe succeeded between VMs %s and %s' % (
                     sender.get('name', sender['id']),
                     receiver.get('name', receiver['id'])))
+        if preferred_pair and preferred_pair in validated:
+            validated.remove(preferred_pair)
+            validated.insert(0, preferred_pair)
         last_err = None
-        for bind_ip, peer_ip in candidates:
+        for bind_ip, peer_ip in validated:
             LOG.warning(
                 'Sending %d bound ICMP (xmit-only) from %s to %s',
                 packet_count, bind_ip, peer_ip)
             try:
-                self._send_ping_packets_bound(
+                total_xmit = self._send_ping_packets_bound(
                     ssh_sender, bind_ip, peer_ip, packet_count,
                     min_packets=1, accept_xmit_only=True)
-                return bind_ip, peer_ip
+                LOG.warning(
+                    'Transmitted %d ICMP probes on verified pair %s -> %s',
+                    total_xmit, bind_ip, peer_ip)
+                return bind_ip, peer_ip, total_xmit
             except AssertionError as exc:
                 last_err = exc
                 LOG.warning(
                     'Cross-subnet xmit failed for %s -> %s: %s',
                     bind_ip, peer_ip, exc)
         self.fail(
-            'No cross-subnet pair transmitted ICMP for router traffic test: '
-            '%s' % last_err)
+            'Probe-verified cross-subnet pairs failed to transmit ICMP: %s' %
+            last_err)
 
     def _sample_map_deltas(self, after, before):
         deltas = {}
@@ -282,14 +293,26 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
 
     def _wait_for_router_traffic_counters(self, hypervisor_ip, baseline_pkts,
                                           baseline_bytes, min_packets=None,
-                                          min_bytes=None):
+                                          min_bytes=None, ssh_sender=None,
+                                          packet_count=None,
+                                          traffic_pair=None):
         min_packets = (min_packets if min_packets is not None else
                        self._min_expected_packets())
         min_bytes = (min_bytes if min_bytes is not None else
-                     self._min_expected_bytes())
+                     self._min_expected_bytes(min_packets))
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            if (attempt > 0 and ssh_sender is not None and traffic_pair and
+                    packet_count):
+                bind_ip, peer_ip = traffic_pair
+                LOG.warning(
+                    'Re-sending router traffic (attempt %s/%s) %s -> %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    bind_ip, peer_ip)
+                self._send_ping_packets_bound(
+                    ssh_sender, bind_ip, peer_ip, packet_count,
+                    min_packets=1, accept_xmit_only=True)
             pkts_after = self._router_port_sample_map(
                 hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
             bytes_after = self._router_port_sample_map(
@@ -353,26 +376,28 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         bind_ip, peer_ip = self._select_cross_subnet_pair(
             ssh_sender, sender, receiver)
         packet_count = self._traffic_ping_count()
-        min_packets, min_bytes = self._effective_traffic_expectations(
-            ssh_sender)
-        LOG.warning(
-            'Router traffic test: %s bind %s -> %s (hypervisor %s), count %s, '
-            'min pkts %s',
-            sender.get('name', sender['id']), bind_ip, peer_ip, hypervisor_ip,
-            packet_count, min_packets)
 
         baseline_pkts = self._router_port_sample_map(
             hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
         baseline_bytes = self._router_port_sample_map(
             hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
 
-        bind_ip, peer_ip = self._send_router_cross_subnet_traffic(
-            ssh_sender, sender, receiver, packet_count, min_packets,
+        bind_ip, peer_ip, total_xmit = self._send_router_cross_subnet_traffic(
+            ssh_sender, sender, receiver, packet_count,
             preferred_pair=(bind_ip, peer_ip))
+        min_packets = self._min_expected_packets(transmitted=total_xmit)
+        min_bytes = self._min_expected_bytes(min_packets)
+        LOG.warning(
+            'Router traffic test: %s bind %s -> %s (hypervisor %s), xmit %s, '
+            'min pkts %s',
+            sender.get('name', sender['id']), bind_ip, peer_ip, hypervisor_ip,
+            total_xmit, min_packets)
 
         result = self._wait_for_router_traffic_counters(
             hypervisor_ip, baseline_pkts, baseline_bytes,
-            min_packets=min_packets, min_bytes=min_bytes)
+            min_packets=min_packets, min_bytes=min_bytes,
+            ssh_sender=ssh_sender, packet_count=packet_count,
+            traffic_pair=(bind_ip, peer_ip))
         LOG.warning(
             'Router port traffic OK: pkts total +%s (peak port %s +%s), '
             'bytes total +%s (peak port %s +%s)',

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -216,13 +216,9 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
     def _send_router_cross_subnet_traffic(self, ssh_sender, bind_ip, peer_ip,
                                           packet_count, min_packets):
         """Generate L3 ICMP through the Neutron router for port counter tests."""
-        if self._guest_has_passwordless_sudo(ssh_sender):
-            self._send_bound_ping_flood_on_guest(
-                ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
-            return
         LOG.warning(
-            'No passwordless sudo; sending slow bound ICMP from %s to %s',
-            bind_ip, peer_ip)
+            'Sending %d bound ICMP echo requests from %s to %s',
+            packet_count, bind_ip, peer_ip)
         self._send_ping_packets_bound(
             ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
 

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -102,29 +102,6 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         return (self._min_expected_packets() *
                 CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
 
-    def _slow_ping_cap(self):
-        return min(
-            self._traffic_ping_count(),
-            int(metrics_base.PING_MAX_WALL_SECONDS /
-                metrics_base.PING_SLOW_INTERVAL_SEC))
-
-    def _effective_traffic_expectations(self, ssh_sender):
-        """Return (min_packets, min_bytes) achievable on this guest."""
-        min_packets = self._min_expected_packets()
-        min_bytes = self._min_expected_bytes()
-        if self._guest_has_passwordless_sudo(ssh_sender):
-            return min_packets, min_bytes
-        capped = self._slow_ping_cap()
-        if capped >= min_packets:
-            return min_packets, min_bytes
-        LOG.warning(
-            'No passwordless sudo on sender; expecting >= %d router pkts/bytes '
-            '(slow ping cap %d, configured min pkts %d)',
-            capped, capped, min_packets)
-        return capped, (
-            capped *
-            CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
-
     def _populate_provider_networks(self, servers):
         for server in servers:
             server['provider_networks'] = server.get('trunk_networks', [])
@@ -148,43 +125,78 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
             return None
         return self.test_network_dict.get(mgmt_name, {}).get('net-id')
 
-    def _cross_subnet_peer_ips(self, sender, receiver):
-        """Return (sender_bind_ip, receiver_ip) on different subnets."""
+    @staticmethod
+    def _same_ipv4_subnet(ip_a, ip_b):
+        return ip_a.split('.')[:3] == ip_b.split('.')[:3]
+
+    def _cross_subnet_peer_candidates(self, sender, receiver):
+        """Return ordered (bind_ip, peer_ip) pairs that traverse the router.
+
+        Prefer mgmt -> dataplane: binding to an external IP and pinging a
+        directly-connected mgmt address often fails because Linux selects the
+        mgmt interface for the destination subnet.
+        """
         mgmt_net_id = self._mgmt_network_id()
-        recv_ip = None
-        for r_net in receiver['provider_networks']:
-            if mgmt_net_id and r_net['network_id'] == mgmt_net_id:
-                recv_ip = r_net['ip_address']
-                break
-        if not recv_ip:
-            recv_ip = receiver['provider_networks'][0]['ip_address']
-        recv_net_id = None
-        for r_net in receiver['provider_networks']:
-            if r_net['ip_address'] == recv_ip:
-                recv_net_id = r_net['network_id']
-                break
-        send_bind_ip = None
+        scored = []
+        seen = set()
         for s_net in sender['provider_networks']:
-            if recv_net_id and s_net['network_id'] != recv_net_id:
-                send_bind_ip = s_net['ip_address']
-                break
-        if not send_bind_ip:
-            for s_net in sender['provider_networks']:
-                if mgmt_net_id and s_net['network_id'] != mgmt_net_id:
-                    send_bind_ip = s_net['ip_address']
-                    break
-        if not send_bind_ip or not recv_ip:
+            for r_net in receiver['provider_networks']:
+                if s_net['network_id'] == r_net['network_id']:
+                    continue
+                bind_ip = s_net['ip_address']
+                peer_ip = r_net['ip_address']
+                if self._same_ipv4_subnet(bind_ip, peer_ip):
+                    continue
+                key = (bind_ip, peer_ip)
+                if key in seen:
+                    continue
+                seen.add(key)
+                s_mgmt = mgmt_net_id and s_net['network_id'] == mgmt_net_id
+                r_mgmt = mgmt_net_id and r_net['network_id'] == mgmt_net_id
+                if s_mgmt and not r_mgmt:
+                    score = 0
+                elif not s_mgmt and not r_mgmt:
+                    score = 1
+                elif s_mgmt and r_mgmt:
+                    score = 2
+                else:
+                    score = 3
+                scored.append((score, bind_ip, peer_ip))
+        scored.sort(key=lambda item: item[0])
+        return [(bind_ip, peer_ip) for _, bind_ip, peer_ip in scored]
+
+    def _select_cross_subnet_pair(self, ssh_sender, sender, receiver):
+        """Pick a routable cross-subnet IP pair, probing with bound ICMP."""
+        candidates = self._cross_subnet_peer_candidates(sender, receiver)
+        if not candidates:
             self.fail(
                 'Could not find cross-subnet IPs between VMs %s and %s. '
                 'Ensure mgmt and at least one other routed network.' % (
                     sender.get('name', sender['id']),
                     receiver.get('name', receiver['id'])))
-        if send_bind_ip.split('.')[:3] == recv_ip.split('.')[:3]:
-            self.fail(
-                'Sender bind %s and receiver %s appear to share a subnet; '
-                'router traffic test requires different subnets.' % (
-                    send_bind_ip, recv_ip))
-        return send_bind_ip, recv_ip
+        for bind_ip, peer_ip in candidates:
+            LOG.warning(
+                'Probing cross-subnet pair bind %s -> %s', bind_ip, peer_ip)
+            if self._probe_bound_ping(ssh_sender, bind_ip, peer_ip):
+                LOG.warning(
+                    'Using routable cross-subnet pair bind %s -> %s',
+                    bind_ip, peer_ip)
+                return bind_ip, peer_ip
+        bind_ip, peer_ip = candidates[0]
+        LOG.warning(
+            'No bound ICMP probe succeeded; using best candidate bind %s -> %s '
+            'with UDP flood only',
+            bind_ip, peer_ip)
+        return bind_ip, peer_ip
+
+    def _send_router_cross_subnet_traffic(self, ssh_sender, bind_ip, peer_ip,
+                                          packet_count):
+        """Generate L3 traffic through the Neutron router via bound UDP."""
+        LOG.warning(
+            'Sending %d bound UDP datagrams from %s to %s',
+            packet_count, bind_ip, peer_ip)
+        self._flood_udp_dataplane(
+            ssh_sender, bind_ip, peer_ip, packet_count)
 
     def _sample_map_deltas(self, after, before):
         deltas = {}
@@ -261,7 +273,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
     # --- Traffic ---
 
     def test_ovnc_router_port_traffic_increments_with_cross_subnet_traffic(self):
-        """Boot two VMs on routed subnets, ping across router, verify counters."""
+        """Boot two VMs on routed subnets, send L3 traffic, verify counters."""
         servers, key_pair = self._boot_router_traffic_vms()
         self.assertEqual(2, len(servers), 'Test requires exactly two VMs')
         if not servers[0].get('provider_networks'):
@@ -271,29 +283,27 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
                 self._populate_provider_networks(servers)
 
         sender, receiver = servers[0], servers[1]
-        bind_ip, peer_ip = self._cross_subnet_peer_ips(sender, receiver)
         hypervisor_ip = sender['hypervisor_ip']
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        bind_ip, peer_ip = self._select_cross_subnet_pair(
+            ssh_sender, sender, receiver)
+        packet_count = self._traffic_ping_count()
         LOG.warning(
-            'Router traffic test: %s ping -I %s -> %s (hypervisor %s), count %s',
+            'Router traffic test: %s bind %s -> %s (hypervisor %s), count %s',
             sender.get('name', sender['id']), bind_ip, peer_ip, hypervisor_ip,
-            self._traffic_ping_count())
+            packet_count)
 
         baseline_pkts = self._router_port_sample_map(
             hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
         baseline_bytes = self._router_port_sample_map(
             hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
 
-        ssh_sender = self.get_remote_client(
-            sender['fip'], self.instance_user, key_pair['private_key'])
-        min_packets, min_bytes = self._effective_traffic_expectations(
-            ssh_sender)
-        self._send_ping_packets_bound(
-            ssh_sender, bind_ip, peer_ip, self._traffic_ping_count(),
-            min_packets)
+        self._send_router_cross_subnet_traffic(
+            ssh_sender, bind_ip, peer_ip, packet_count)
 
         result = self._wait_for_router_traffic_counters(
-            hypervisor_ip, baseline_pkts, baseline_bytes,
-            min_packets=min_packets, min_bytes=min_bytes)
+            hypervisor_ip, baseline_pkts, baseline_bytes)
         LOG.warning(
             'Router port traffic OK: pkts series %s +%s, bytes series %s +%s',
             result['pkts_key'], result['pkts_delta'],

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -102,6 +102,29 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         return (self._min_expected_packets() *
                 CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
 
+    def _slow_ping_cap(self):
+        return min(
+            self._traffic_ping_count(),
+            int(metrics_base.PING_MAX_WALL_SECONDS /
+                metrics_base.PING_SLOW_INTERVAL_SEC))
+
+    def _effective_traffic_expectations(self, ssh_sender):
+        """Return (min_packets, min_bytes) achievable on this guest."""
+        min_packets = self._min_expected_packets()
+        min_bytes = self._min_expected_bytes()
+        if self._guest_has_passwordless_sudo(ssh_sender):
+            return min_packets, min_bytes
+        capped = self._slow_ping_cap()
+        if capped >= min_packets:
+            return min_packets, min_bytes
+        LOG.warning(
+            'No passwordless sudo on sender; expecting >= %d router pkts/bytes '
+            '(slow ping cap %d, configured min pkts %d)',
+            capped, capped, min_packets)
+        return capped, (
+            capped *
+            CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
+
     def _populate_provider_networks(self, servers):
         for server in servers:
             server['provider_networks'] = server.get('trunk_networks', [])
@@ -176,9 +199,12 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         return key, deltas[key]
 
     def _wait_for_router_traffic_counters(self, hypervisor_ip, baseline_pkts,
-                                          baseline_bytes):
-        min_packets = self._min_expected_packets()
-        min_bytes = self._min_expected_bytes()
+                                          baseline_bytes, min_packets=None,
+                                          min_bytes=None):
+        min_packets = (min_packets if min_packets is not None else
+                       self._min_expected_packets())
+        min_bytes = (min_bytes if min_bytes is not None else
+                     self._min_expected_bytes())
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
@@ -259,12 +285,15 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
 
         ssh_sender = self.get_remote_client(
             sender['fip'], self.instance_user, key_pair['private_key'])
+        min_packets, min_bytes = self._effective_traffic_expectations(
+            ssh_sender)
         self._send_ping_packets_bound(
             ssh_sender, bind_ip, peer_ip, self._traffic_ping_count(),
-            self._min_expected_packets())
+            min_packets)
 
         result = self._wait_for_router_traffic_counters(
-            hypervisor_ip, baseline_pkts, baseline_bytes)
+            hypervisor_ip, baseline_pkts, baseline_bytes,
+            min_packets=min_packets, min_bytes=min_bytes)
         LOG.warning(
             'Router port traffic OK: pkts series %s +%s, bytes series %s +%s',
             result['pkts_key'], result['pkts_delta'],

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -95,7 +95,8 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
     def _min_expected_packets(self):
         count = self._traffic_ping_count()
         tolerance = (
-            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+            CONF.nfv_plugin_options.
+            network_exporter_router_traffic_packet_tolerance_pct)
         return int(count * (100 - tolerance) / 100)
 
     def _min_expected_bytes(self):
@@ -214,29 +215,16 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
 
     def _send_router_cross_subnet_traffic(self, ssh_sender, bind_ip, peer_ip,
                                           packet_count, min_packets):
-        """Generate L3 traffic through the Neutron router.
-
-        ovnc_router_port_traffic_* tracks ICMP-sized L3 packets on logical
-        router ports; bound ICMP is the primary generator. UDP is a fallback
-        when ICMP cannot be sent at the required rate.
-        """
-        LOG.warning(
-            'Sending %d bound ICMP echo requests from %s to %s',
-            packet_count, bind_ip, peer_ip)
-        try:
-            self._send_ping_packets_bound(
+        """Generate L3 ICMP through the Neutron router for port counter tests."""
+        if self._guest_has_passwordless_sudo(ssh_sender):
+            self._send_bound_ping_flood_on_guest(
                 ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
             return
-        except AssertionError as exc:
-            LOG.warning(
-                'Bound ICMP flood from %s to %s failed (%s); '
-                'falling back to bound UDP',
-                bind_ip, peer_ip, exc)
         LOG.warning(
-            'Sending %d bound UDP datagrams from %s to %s',
-            packet_count, bind_ip, peer_ip)
-        self._flood_udp_dataplane(
-            ssh_sender, bind_ip, peer_ip, packet_count)
+            'No passwordless sudo; sending slow bound ICMP from %s to %s',
+            bind_ip, peer_ip)
+        self._send_ping_packets_bound(
+            ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
 
     def _sample_map_deltas(self, after, before):
         deltas = {}
@@ -269,9 +257,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
 
     def _wait_for_router_traffic_counters(self, hypervisor_ip, baseline_pkts,
                                           baseline_bytes, min_packets=None,
-                                          min_bytes=None, ssh_sender=None,
-                                          bind_ip=None, peer_ip=None,
-                                          packet_count=None):
+                                          min_bytes=None):
         min_packets = (min_packets if min_packets is not None else
                        self._min_expected_packets())
         min_bytes = (min_bytes if min_bytes is not None else
@@ -279,13 +265,6 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
-            if (attempt > 0 and ssh_sender is not None and bind_ip and
-                    peer_ip and packet_count):
-                LOG.warning(
-                    'Re-sending router traffic (attempt %s/%s)',
-                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS)
-                self._send_router_cross_subnet_traffic(
-                    ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
             pkts_after = self._router_port_sample_map(
                 hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_PKTS_METRIC)
             bytes_after = self._router_port_sample_map(
@@ -367,9 +346,7 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
 
         result = self._wait_for_router_traffic_counters(
             hypervisor_ip, baseline_pkts, baseline_bytes,
-            min_packets=min_packets, min_bytes=min_bytes,
-            ssh_sender=ssh_sender, bind_ip=bind_ip, peer_ip=peer_ip,
-            packet_count=packet_count)
+            min_packets=min_packets, min_bytes=min_bytes)
         LOG.warning(
             'Router port traffic OK: pkts total +%s (peak port %s +%s), '
             'bytes total +%s (peak port %s +%s)',

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_router_port_traffic_metrics.py
@@ -213,14 +213,43 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
             bind_ip, peer_ip)
         return bind_ip, peer_ip
 
-    def _send_router_cross_subnet_traffic(self, ssh_sender, bind_ip, peer_ip,
-                                          packet_count, min_packets):
-        """Generate L3 ICMP through the Neutron router for port counter tests."""
-        LOG.warning(
-            'Sending %d bound ICMP echo requests from %s to %s',
-            packet_count, bind_ip, peer_ip)
-        self._send_ping_packets_bound(
-            ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
+    def _send_router_cross_subnet_traffic(self, ssh_sender, sender, receiver,
+                                          packet_count, min_packets,
+                                          preferred_pair=None):
+        """Generate L3 ICMP through the Neutron router for port counter tests.
+
+        Router port counters reflect forwarded probes; ICMP replies are not
+        required. Try each cross-subnet bind/peer pair until one transmits.
+        """
+        candidates = self._cross_subnet_peer_candidates(sender, receiver)
+        if preferred_pair and preferred_pair in candidates:
+            candidates.remove(preferred_pair)
+            candidates.insert(0, preferred_pair)
+        elif preferred_pair:
+            candidates.insert(0, preferred_pair)
+        if not candidates:
+            self.fail(
+                'Could not find cross-subnet IPs between VMs %s and %s' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        last_err = None
+        for bind_ip, peer_ip in candidates:
+            LOG.warning(
+                'Sending %d bound ICMP (xmit-only) from %s to %s',
+                packet_count, bind_ip, peer_ip)
+            try:
+                self._send_ping_packets_bound(
+                    ssh_sender, bind_ip, peer_ip, packet_count,
+                    min_packets=1, accept_xmit_only=True)
+                return bind_ip, peer_ip
+            except AssertionError as exc:
+                last_err = exc
+                LOG.warning(
+                    'Cross-subnet xmit failed for %s -> %s: %s',
+                    bind_ip, peer_ip, exc)
+        self.fail(
+            'No cross-subnet pair transmitted ICMP for router traffic test: '
+            '%s' % last_err)
 
     def _sample_map_deltas(self, after, before):
         deltas = {}
@@ -337,8 +366,9 @@ class TestOvncRouterPortTrafficMetrics(metrics_base.NetworkExporterMetricsBase):
         baseline_bytes = self._router_port_sample_map(
             hypervisor_ip, metrics_base.OVNC_ROUTER_PORT_TRAFFIC_BYTES_METRIC)
 
-        self._send_router_cross_subnet_traffic(
-            ssh_sender, bind_ip, peer_ip, packet_count, min_packets)
+        bind_ip, peer_ip = self._send_router_cross_subnet_traffic(
+            ssh_sender, sender, receiver, packet_count, min_packets,
+            preferred_pair=(bind_ip, peer_ip))
 
         result = self._wait_for_router_traffic_counters(
             hypervisor_ip, baseline_pkts, baseline_bytes,

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_txn_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovnc_txn_metrics.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import uuid
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+OVNC_TXN_SUCCESS_METRIC = metrics_base.OVNC_TXN_SUCCESS_METRIC
+OVNC_TXN_UNCOMMITTED_METRIC = metrics_base.OVNC_TXN_UNCOMMITTED_METRIC
+OVNC_TXN_ABORTED_METRIC = metrics_base.OVNC_TXN_ABORTED_METRIC
+OVNC_TXN_ERROR_METRIC = metrics_base.OVNC_TXN_ERROR_METRIC
+
+
+class TestOvncTxnMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovnc_txn_* counters against ovn-controller coverage/show (7.2)."""
+
+    def _pick_ovn_hypervisor(self):
+        hypervisors = self._get_ssh_hypervisors('')
+        self.assertNotEmpty(
+            hypervisors,
+            'No compute hypervisors available for OVN txn metrics')
+        ovn_hypervisors = self._hypervisors_with_ovn_controller(hypervisors)
+        self.assertNotEmpty(
+            ovn_hypervisors,
+            'No OVN controller on hypervisors %s' % hypervisors)
+        return ovn_hypervisors[0]
+
+    def test_ovnc_txn_success_reported(self):
+        """Verify ovnc_txn_success on OVN :1981 and metric-storage."""
+        self._assert_ovnc_txn_metric_reported(OVNC_TXN_SUCCESS_METRIC)
+
+    def test_ovnc_txn_uncommitted_reported(self):
+        """Verify ovnc_txn_uncommitted on OVN :1981 and metric-storage."""
+        self._assert_ovnc_txn_metric_reported(OVNC_TXN_UNCOMMITTED_METRIC)
+
+    def test_ovnc_txn_aborted_reported(self):
+        """Verify ovnc_txn_aborted on OVN :1981 and metric-storage."""
+        self._assert_ovnc_txn_metric_reported(OVNC_TXN_ABORTED_METRIC)
+
+    def test_ovnc_txn_error_reported(self):
+        """Verify ovnc_txn_error on OVN :1981 and metric-storage."""
+        self._assert_ovnc_txn_metric_reported(OVNC_TXN_ERROR_METRIC)
+
+    def test_ovnc_txn_success_increases_with_network_create_delete(self):
+        """Create/delete a Neutron network and verify txn_success increases."""
+        hypervisor_ip = self._pick_ovn_hypervisor()
+        baseline_show, baseline_live = self._ovnc_txn_success_totals(
+            hypervisor_ip)
+        LOG.warning(
+            'OVN txn_success baseline on %s: coverage/show=%s live=%s',
+            hypervisor_ip, baseline_show, baseline_live)
+
+        network_name = 'tempest-ovnc-txn-%s' % uuid.uuid4().hex[:8]
+        network = self.os_admin.networks_client.create_network(
+            body={'network': {'name': network_name}})['network']
+        self.addCleanup(
+            self.os_admin.networks_client.delete_network, network['id'])
+
+        last = {}
+        last_exc = None
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            try:
+                show_total, live_total = self._ovnc_txn_success_totals(
+                    hypervisor_ip)
+                last = {
+                    'show_total': show_total,
+                    'live_total': live_total,
+                    'baseline_show': baseline_show,
+                    'baseline_live': baseline_live,
+                }
+                self.assertGreaterEqual(
+                    show_total, baseline_show + 1,
+                    'coverage/show txn_success did not increase on %s' % (
+                        hypervisor_ip))
+                self.assertGreaterEqual(
+                    live_total, baseline_live + 1,
+                    'live :1981 ovnc_txn_success did not increase on %s' % (
+                        hypervisor_ip))
+                LOG.warning(
+                    'OVN txn_success increased on %s (attempt %s): '
+                    'show +%s live +%s',
+                    hypervisor_ip, attempt + 1,
+                    show_total - baseline_show,
+                    live_total - baseline_live)
+                return
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for ovnc_txn_success increase: %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for ovnc_txn_success increase after network '
+            'create on %s. Last %s; last error: %s' % (
+                hypervisor_ip, last, last_exc))

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_flow_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_flow_metrics.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class TestOvsDatapathFlowMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovs_datapath_flows_total with VM traffic (Test Suite 4.1)."""
+
+    TEST_NAME = 'network_exporter_datapath_flow'
+
+    def _ensure_test_setup(self):
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_datapath_flow_test_networks(self, test_networks):
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('port_type') == 'direct':
+                continue
+            filtered.append(network)
+        if not any(not net.get('mgmt') for net in filtered):
+            raise unittest.SkipTest(
+                'No shared normal provider test-network in tempest_config.yml '
+                'for %s. Add a test-network with port_type: normal (e.g. '
+                'tag: external) in addition to mgmt.' % self.TEST_NAME)
+        LOG.warning(
+            'Datapath flow metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_datapath_flow_boot_kwargs(self):
+        ports_filter = 'external,normal'
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _boot_datapath_flow_vms(self):
+        self._ensure_test_setup()
+        boot_kwargs = self._build_datapath_flow_boot_kwargs()
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = (
+            self._filter_datapath_flow_test_networks(full_test_networks))
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _traffic_ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+
+    def _min_expected_packets(self):
+        count = self._traffic_ping_count()
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _populate_provider_networks(self, servers):
+        for server in servers:
+            server['provider_networks'] = server.get('trunk_networks', [])
+            server['provider_networks'] += server.get('transparent_networks', [])
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server['id'])['ports']
+            for port in ports:
+                if not port.get('fixed_ips'):
+                    continue
+                provider_dict = {
+                    'network_id': port['network_id'],
+                    'mac_address': port['mac_address'],
+                    'ip_address': port['fixed_ips'][0]['ip_address'],
+                    'port_id': port['id'],
+                }
+                server['provider_networks'].append(provider_dict)
+
+    def _mgmt_network_id(self):
+        mgmt_name = getattr(self, 'mgmt_network', None)
+        if not mgmt_name:
+            return None
+        return self.test_network_dict.get(mgmt_name, {}).get('net-id')
+
+    def _dataplane_peer_ip(self, sender, receiver):
+        mgmt_net_id = self._mgmt_network_id()
+        shared = []
+        for recv_net in receiver['provider_networks']:
+            for send_net in sender['provider_networks']:
+                if recv_net['network_id'] == send_net['network_id']:
+                    shared.append(recv_net)
+                    break
+        if not shared:
+            self.fail(
+                'No shared provider network between VMs %s and %s' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        for net in shared:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net['ip_address']
+        return shared[0]['ip_address']
+
+    def _wait_for_datapath_flow_increase(self, hypervisor_ip, baseline_flows):
+        min_inc = (
+            CONF.nfv_plugin_options.network_exporter_datapath_min_flow_increase)
+        datapath = self._configured_datapath_name()
+        last_exc = None
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            after = self._datapath_sample_map(
+                hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
+            current = after.get(datapath, 0)
+            baseline = baseline_flows.get(datapath, 0)
+            delta = current - baseline
+            last = {
+                'datapath': datapath,
+                'baseline': baseline,
+                'current': current,
+                'delta': delta,
+            }
+            try:
+                self.assertGreaterEqual(
+                    delta, min_inc,
+                    'ovs_datapath_flows_total delta %s' % last)
+                self._assert_datapath_matches_dpctl(
+                    hypervisor_ip,
+                    metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC,
+                    datapath)
+                LOG.warning(
+                    'Datapath flows increased (attempt %s): %s',
+                    attempt + 1, last)
+                return last
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for datapath flows: %s; %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for ovs_datapath_flows_total increase. '
+            'Last %s; last error: %s' % (last, last_exc))
+
+    def test_ovs_datapath_flows_total_reported(self):
+        """Verify ovs_datapath_flows_total on compute and metric-storage."""
+        self._assert_datapath_metric_reported(
+            metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
+
+    def test_ovs_datapath_flows_increase_with_vm_traffic(self):
+        """Boot two VMs, send ICMP, verify datapath flow count increases."""
+        servers, key_pair = self._boot_datapath_flow_vms()
+        self.assertEqual(2, len(servers), 'Test requires exactly two VMs')
+        if not servers[0].get('provider_networks'):
+            if self.test_all_provider_networks and servers[0].get('fip'):
+                self.verify_provider_networks(servers, key_pair)
+            else:
+                self._populate_provider_networks(servers)
+
+        sender, receiver = servers[0], servers[1]
+        hypervisor_ip = sender['hypervisor_ip']
+        peer_ip = self._dataplane_peer_ip(sender, receiver)
+        datapath = self._configured_datapath_name()
+
+        baseline_flows = self._datapath_sample_map(
+            hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
+        LOG.warning(
+            'Datapath flow test: %s -> %s on %s datapath %s, post-boot flows %s',
+            sender.get('name', sender['id']), peer_ip, hypervisor_ip,
+            datapath, baseline_flows)
+
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        self._send_ping_packets(
+            ssh_sender, peer_ip, self._traffic_ping_count(),
+            self._min_expected_packets())
+
+        result = self._wait_for_datapath_flow_increase(
+            hypervisor_ip, baseline_flows)
+        LOG.warning(
+            'Datapath flows OK: datapath %s +%s (now %s)',
+            result['datapath'], result['delta'], result['current'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_flow_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_flow_metrics.py
@@ -137,36 +137,62 @@ class TestOvsDatapathFlowMetrics(metrics_base.NetworkExporterMetricsBase):
             return net['ip_address']
         return shared[0]['ip_address']
 
-    def _wait_for_datapath_flow_increase(self, hypervisor_ip, baseline_flows):
+    def _wait_for_datapath_flow_increase(self, hypervisor_ip, baseline_flows,
+                                         dpctl_baseline):
         min_inc = (
             CONF.nfv_plugin_options.network_exporter_datapath_min_flow_increase)
         labels = self._resolve_datapath_labels(
             hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
         datapath = labels['name']
+        datapath_type = labels.get('type')
+        baseline = baseline_flows.get(datapath, 0)
+        peak = baseline
+        dpctl_baseline_flows = dpctl_baseline['flows']
+        dpctl_baseline_hits = dpctl_baseline.get('hit', 0)
+        min_hits = min(
+            100,
+            CONF.nfv_plugin_options.network_exporter_datapath_lookup_min_hits)
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
-            after = self._datapath_sample_map(
+            after = self._datapath_live_sample_map(
                 hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
             current = after.get(datapath, 0)
-            baseline = baseline_flows.get(datapath, 0)
-            delta = current - baseline
+            peak = max(peak, current)
+            dpctl_stats = self._ovs_datapath_dpctl_stats(
+                hypervisor_ip, datapath, datapath_type=datapath_type)
+            dpctl_flows = dpctl_stats['flows']
+            dpctl_hits = dpctl_stats.get('hit', 0)
+            exporter_delta = peak - baseline
+            dpctl_flow_delta = dpctl_flows - dpctl_baseline_flows
+            dpctl_hits_delta = dpctl_hits - dpctl_baseline_hits
             last = {
                 'datapath': '%s@%s' % (labels.get('type'), datapath),
                 'baseline': baseline,
                 'current': current,
-                'delta': delta,
+                'peak': peak,
+                'exporter_delta': exporter_delta,
+                'dpctl_baseline_flows': dpctl_baseline_flows,
+                'dpctl_current_flows': dpctl_flows,
+                'dpctl_flow_delta': dpctl_flow_delta,
+                'dpctl_hits_delta': dpctl_hits_delta,
             }
             try:
-                self.assertGreaterEqual(
-                    delta, min_inc,
-                    'ovs_datapath_flows_total delta %s' % last)
+                flow_increased = (
+                    exporter_delta >= min_inc or dpctl_flow_delta >= min_inc)
+                hits_increased = dpctl_hits_delta >= min_hits
+                self.assertTrue(
+                    flow_increased or hits_increased,
+                    'No ovs_datapath flow or lookup hit increase after traffic '
+                    '(need flow +%s or dpctl hits +%s): %s' % (
+                        min_inc, min_hits, last))
                 self._assert_datapath_matches_dpctl(
                     hypervisor_ip,
                     metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
                 LOG.warning(
-                    'Datapath flows increased (attempt %s): %s',
+                    'Datapath traffic validated (attempt %s): %s',
                     attempt + 1, last)
+                last['delta'] = exporter_delta
                 return last
             except Exception as exc:
                 last_exc = exc
@@ -201,12 +227,17 @@ class TestOvsDatapathFlowMetrics(metrics_base.NetworkExporterMetricsBase):
         labels = self._resolve_datapath_labels(
             hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
 
-        baseline_flows = self._datapath_sample_map(
+        baseline_flows = self._datapath_live_sample_map(
             hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
+        dpctl_baseline = self._ovs_datapath_dpctl_stats(
+            hypervisor_ip, labels['name'],
+            datapath_type=labels.get('type'))
         LOG.warning(
-            'Datapath flow test: %s -> %s on %s datapath %s@%s, post-boot flows %s',
+            'Datapath flow test: %s -> %s on %s datapath %s@%s, post-boot '
+            'live flows %s dpctl %s',
             sender.get('name', sender['id']), peer_ip, hypervisor_ip,
-            labels.get('type'), labels['name'], baseline_flows)
+            labels.get('type'), labels['name'], baseline_flows,
+            dpctl_baseline)
 
         ssh_sender = self.get_remote_client(
             sender['fip'], self.instance_user, key_pair['private_key'])
@@ -215,7 +246,7 @@ class TestOvsDatapathFlowMetrics(metrics_base.NetworkExporterMetricsBase):
             self._min_expected_packets())
 
         result = self._wait_for_datapath_flow_increase(
-            hypervisor_ip, baseline_flows)
+            hypervisor_ip, baseline_flows, dpctl_baseline)
         LOG.warning(
             'Datapath flows OK: datapath %s +%s (now %s)',
             result['datapath'], result['delta'], result['current'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_flow_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_flow_metrics.py
@@ -140,7 +140,9 @@ class TestOvsDatapathFlowMetrics(metrics_base.NetworkExporterMetricsBase):
     def _wait_for_datapath_flow_increase(self, hypervisor_ip, baseline_flows):
         min_inc = (
             CONF.nfv_plugin_options.network_exporter_datapath_min_flow_increase)
-        datapath = self._configured_datapath_name()
+        labels = self._resolve_datapath_labels(
+            hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
+        datapath = labels['name']
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
@@ -150,7 +152,7 @@ class TestOvsDatapathFlowMetrics(metrics_base.NetworkExporterMetricsBase):
             baseline = baseline_flows.get(datapath, 0)
             delta = current - baseline
             last = {
-                'datapath': datapath,
+                'datapath': '%s@%s' % (labels.get('type'), datapath),
                 'baseline': baseline,
                 'current': current,
                 'delta': delta,
@@ -161,8 +163,7 @@ class TestOvsDatapathFlowMetrics(metrics_base.NetworkExporterMetricsBase):
                     'ovs_datapath_flows_total delta %s' % last)
                 self._assert_datapath_matches_dpctl(
                     hypervisor_ip,
-                    metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC,
-                    datapath)
+                    metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
                 LOG.warning(
                     'Datapath flows increased (attempt %s): %s',
                     attempt + 1, last)
@@ -197,14 +198,15 @@ class TestOvsDatapathFlowMetrics(metrics_base.NetworkExporterMetricsBase):
         sender, receiver = servers[0], servers[1]
         hypervisor_ip = sender['hypervisor_ip']
         peer_ip = self._dataplane_peer_ip(sender, receiver)
-        datapath = self._configured_datapath_name()
+        labels = self._resolve_datapath_labels(
+            hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
 
         baseline_flows = self._datapath_sample_map(
             hypervisor_ip, metrics_base.OVS_DATAPATH_FLOWS_TOTAL_METRIC)
         LOG.warning(
-            'Datapath flow test: %s -> %s on %s datapath %s, post-boot flows %s',
+            'Datapath flow test: %s -> %s on %s datapath %s@%s, post-boot flows %s',
             sender.get('name', sender['id']), peer_ip, hypervisor_ip,
-            datapath, baseline_flows)
+            labels.get('type'), labels['name'], baseline_flows)
 
         ssh_sender = self.get_remote_client(
             sender['fip'], self.instance_user, key_pair['private_key'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_lookup_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_lookup_metrics.py
@@ -139,13 +139,13 @@ class TestOvsDatapathLookupMetrics(metrics_base.NetworkExporterMetricsBase):
 
     def _baseline_lookup_counters(self, hypervisor_ip):
         return {
-            'hits': self._datapath_metric_value(
+            'hits': self._datapath_live_metric_value(
                 hypervisor_ip,
                 metrics_base.OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC) or 0,
-            'missed': self._datapath_metric_value(
+            'missed': self._datapath_live_metric_value(
                 hypervisor_ip,
                 metrics_base.OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC) or 0,
-            'lost': self._datapath_metric_value(
+            'lost': self._datapath_live_metric_value(
                 hypervisor_ip,
                 metrics_base.OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC) or 0,
         }

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_lookup_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_lookup_metrics.py
@@ -138,26 +138,23 @@ class TestOvsDatapathLookupMetrics(metrics_base.NetworkExporterMetricsBase):
         return shared[0]['ip_address']
 
     def _baseline_lookup_counters(self, hypervisor_ip):
-        datapath = self._configured_datapath_name()
         return {
             'hits': self._datapath_metric_value(
                 hypervisor_ip,
-                metrics_base.OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC,
-                datapath) or 0,
+                metrics_base.OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC) or 0,
             'missed': self._datapath_metric_value(
                 hypervisor_ip,
-                metrics_base.OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC,
-                datapath) or 0,
+                metrics_base.OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC) or 0,
             'lost': self._datapath_metric_value(
                 hypervisor_ip,
-                metrics_base.OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC,
-                datapath) or 0,
+                metrics_base.OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC) or 0,
         }
 
     def _wait_for_datapath_lookup_counters(self, hypervisor_ip, baseline):
         min_hits = (
             CONF.nfv_plugin_options.network_exporter_datapath_lookup_min_hits)
-        datapath = self._configured_datapath_name()
+        labels = self._resolve_datapath_labels(
+            hypervisor_ip, metrics_base.OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC)
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
@@ -166,7 +163,7 @@ class TestOvsDatapathLookupMetrics(metrics_base.NetworkExporterMetricsBase):
                 key: current[key] - baseline[key]
                 for key in ('hits', 'missed', 'lost')}
             last = {
-                'datapath': datapath,
+                'datapath': '%s@%s' % (labels.get('type'), labels['name']),
                 'baseline': baseline,
                 'current': current,
                 'delta': delta,
@@ -191,7 +188,7 @@ class TestOvsDatapathLookupMetrics(metrics_base.NetworkExporterMetricsBase):
                         metrics_base.OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC,
                         metrics_base.OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC):
                     self._assert_datapath_matches_dpctl(
-                        hypervisor_ip, metric_name, datapath)
+                        hypervisor_ip, metric_name)
                 LOG.warning(
                     'Datapath lookup counters increased (attempt %s): %s',
                     attempt + 1, last)
@@ -236,13 +233,15 @@ class TestOvsDatapathLookupMetrics(metrics_base.NetworkExporterMetricsBase):
         sender, receiver = servers[0], servers[1]
         hypervisor_ip = sender['hypervisor_ip']
         peer_ip = self._dataplane_peer_ip(sender, receiver)
-        datapath = self._configured_datapath_name()
+        labels = self._resolve_datapath_labels(
+            hypervisor_ip, metrics_base.OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC)
         baseline = self._baseline_lookup_counters(hypervisor_ip)
         LOG.warning(
-            'Datapath lookup test: %s -> %s on %s datapath %s, baseline %s, '
+            'Datapath lookup test: %s -> %s on %s datapath %s@%s, baseline %s, '
             'ping count %s',
             sender.get('name', sender['id']), peer_ip, hypervisor_ip,
-            datapath, baseline, self._traffic_ping_count())
+            labels.get('type'), labels['name'], baseline,
+            self._traffic_ping_count())
 
         ssh_sender = self.get_remote_client(
             sender['fip'], self.instance_user, key_pair['private_key'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_lookup_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_datapath_lookup_metrics.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class TestOvsDatapathLookupMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovs_datapath_lookup_* counters with VM traffic (Test Suite 4.2)."""
+
+    TEST_NAME = 'network_exporter_datapath_lookup'
+
+    def _ensure_test_setup(self):
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_datapath_lookup_test_networks(self, test_networks):
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('port_type') == 'direct':
+                continue
+            filtered.append(network)
+        if not any(not net.get('mgmt') for net in filtered):
+            raise unittest.SkipTest(
+                'No shared normal provider test-network in tempest_config.yml '
+                'for %s. Add a test-network with port_type: normal (e.g. '
+                'tag: external) in addition to mgmt.' % self.TEST_NAME)
+        LOG.warning(
+            'Datapath lookup metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_datapath_lookup_boot_kwargs(self):
+        ports_filter = 'external,normal'
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _boot_datapath_lookup_vms(self):
+        self._ensure_test_setup()
+        boot_kwargs = self._build_datapath_lookup_boot_kwargs()
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = (
+            self._filter_datapath_lookup_test_networks(full_test_networks))
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _traffic_ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+
+    def _min_expected_packets(self):
+        count = self._traffic_ping_count()
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _populate_provider_networks(self, servers):
+        for server in servers:
+            server['provider_networks'] = server.get('trunk_networks', [])
+            server['provider_networks'] += server.get('transparent_networks', [])
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server['id'])['ports']
+            for port in ports:
+                if not port.get('fixed_ips'):
+                    continue
+                provider_dict = {
+                    'network_id': port['network_id'],
+                    'mac_address': port['mac_address'],
+                    'ip_address': port['fixed_ips'][0]['ip_address'],
+                    'port_id': port['id'],
+                }
+                server['provider_networks'].append(provider_dict)
+
+    def _mgmt_network_id(self):
+        mgmt_name = getattr(self, 'mgmt_network', None)
+        if not mgmt_name:
+            return None
+        return self.test_network_dict.get(mgmt_name, {}).get('net-id')
+
+    def _dataplane_peer_ip(self, sender, receiver):
+        mgmt_net_id = self._mgmt_network_id()
+        shared = []
+        for recv_net in receiver['provider_networks']:
+            for send_net in sender['provider_networks']:
+                if recv_net['network_id'] == send_net['network_id']:
+                    shared.append(recv_net)
+                    break
+        if not shared:
+            self.fail(
+                'No shared provider network between VMs %s and %s' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        for net in shared:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net['ip_address']
+        return shared[0]['ip_address']
+
+    def _baseline_lookup_counters(self, hypervisor_ip):
+        datapath = self._configured_datapath_name()
+        return {
+            'hits': self._datapath_metric_value(
+                hypervisor_ip,
+                metrics_base.OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC,
+                datapath) or 0,
+            'missed': self._datapath_metric_value(
+                hypervisor_ip,
+                metrics_base.OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC,
+                datapath) or 0,
+            'lost': self._datapath_metric_value(
+                hypervisor_ip,
+                metrics_base.OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC,
+                datapath) or 0,
+        }
+
+    def _wait_for_datapath_lookup_counters(self, hypervisor_ip, baseline):
+        min_hits = (
+            CONF.nfv_plugin_options.network_exporter_datapath_lookup_min_hits)
+        datapath = self._configured_datapath_name()
+        last_exc = None
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            current = self._baseline_lookup_counters(hypervisor_ip)
+            delta = {
+                key: current[key] - baseline[key]
+                for key in ('hits', 'missed', 'lost')}
+            last = {
+                'datapath': datapath,
+                'baseline': baseline,
+                'current': current,
+                'delta': delta,
+            }
+            try:
+                self.assertGreaterEqual(
+                    delta['hits'], min_hits,
+                    'ovs_datapath_lookup_hits_total delta %s' % last)
+                self.assertGreaterEqual(
+                    delta['missed'], 0,
+                    'ovs_datapath_lookup_missed_total delta %s' % last)
+                self.assertGreaterEqual(
+                    delta['lost'], 0,
+                    'ovs_datapath_lookup_lost_total delta %s' % last)
+                if delta['missed'] > delta['hits']:
+                    LOG.warning(
+                        'Lookup missed delta (%s) exceeds hits delta (%s); '
+                        'flow cache may still be warming',
+                        delta['missed'], delta['hits'])
+                for metric_name in (
+                        metrics_base.OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC,
+                        metrics_base.OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC,
+                        metrics_base.OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC):
+                    self._assert_datapath_matches_dpctl(
+                        hypervisor_ip, metric_name, datapath)
+                LOG.warning(
+                    'Datapath lookup counters increased (attempt %s): %s',
+                    attempt + 1, last)
+                return last
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for datapath lookup counters: %s; %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for ovs_datapath_lookup_* counters after '
+            'traffic. Last %s; last error: %s' % (last, last_exc))
+
+    def test_ovs_datapath_lookup_hits_total_reported(self):
+        """Verify ovs_datapath_lookup_hits_total on compute and metric-storage."""
+        self._assert_datapath_metric_reported(
+            metrics_base.OVS_DATAPATH_LOOKUP_HITS_TOTAL_METRIC)
+
+    def test_ovs_datapath_lookup_missed_total_reported(self):
+        """Verify ovs_datapath_lookup_missed_total on compute and metric-storage."""
+        self._assert_datapath_metric_reported(
+            metrics_base.OVS_DATAPATH_LOOKUP_MISSED_TOTAL_METRIC)
+
+    def test_ovs_datapath_lookup_lost_total_reported(self):
+        """Verify ovs_datapath_lookup_lost_total on compute and metric-storage."""
+        self._assert_datapath_metric_reported(
+            metrics_base.OVS_DATAPATH_LOOKUP_LOST_TOTAL_METRIC)
+
+    def test_ovs_datapath_lookup_counters_with_vm_traffic(self):
+        """Boot two VMs, send sustained ICMP, verify lookup counter growth."""
+        servers, key_pair = self._boot_datapath_lookup_vms()
+        self.assertEqual(2, len(servers), 'Test requires exactly two VMs')
+        if not servers[0].get('provider_networks'):
+            if self.test_all_provider_networks and servers[0].get('fip'):
+                self.verify_provider_networks(servers, key_pair)
+            else:
+                self._populate_provider_networks(servers)
+
+        sender, receiver = servers[0], servers[1]
+        hypervisor_ip = sender['hypervisor_ip']
+        peer_ip = self._dataplane_peer_ip(sender, receiver)
+        datapath = self._configured_datapath_name()
+        baseline = self._baseline_lookup_counters(hypervisor_ip)
+        LOG.warning(
+            'Datapath lookup test: %s -> %s on %s datapath %s, baseline %s, '
+            'ping count %s',
+            sender.get('name', sender['id']), peer_ip, hypervisor_ip,
+            datapath, baseline, self._traffic_ping_count())
+
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        self._send_ping_packets(
+            ssh_sender, peer_ip, self._traffic_ping_count(),
+            self._min_expected_packets())
+
+        result = self._wait_for_datapath_lookup_counters(
+            hypervisor_ip, baseline)
+        LOG.warning(
+            'Datapath lookup OK: hits +%s missed +%s lost +%s',
+            result['delta']['hits'], result['delta']['missed'],
+            result['delta']['lost'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -465,6 +465,172 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                 count, iface, dest_ip))
         self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
 
+    def _set_ovs_admin_db_only(self, hypervisor_ip, interface, state):
+        """Set OVS admin_state only (leave kernel veth legs unchanged)."""
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo ovs-vsctl set Interface %s admin_state=%s' % (
+                interface, state))
+
+    def _ensure_veth_port_up(self, hypervisor_ip, iface):
+        """Bring both veth legs and OVS admin up without coupling link toggles."""
+        peer = self._veth_peer_name(iface)
+        self._set_kernel_link_state(hypervisor_ip, peer, 'up')
+        self._set_kernel_link_state(hypervisor_ip, iface, 'up')
+        self._set_ovs_admin_db_only(hypervisor_ip, iface, 'up')
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo ovs-vsctl set Interface %s link_state=up' % iface)
+
+    def _install_tc_ingress_drop(self, hypervisor_ip, iface):
+        """Drop all ingress on the OVS netdev (increments kernel rx_dropped)."""
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo tc qdisc add dev %s handle ffff: ingress 2>/dev/null || true; '
+            'sudo tc filter add dev %s parent ffff: protocol all u32 '
+            'match u32 0 0 action drop 2>/dev/null || true' % (iface, iface))
+        self.addCleanup(self._remove_tc_ingress, hypervisor_ip, iface)
+
+    def _remove_tc_ingress(self, hypervisor_ip, iface):
+        self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo tc qdisc del dev %s ingress 2>/dev/null || true' % iface)
+
+    def _install_tc_egress_corrupt(self, hypervisor_ip, iface):
+        """Corrupt all egress on the OVS netdev (may increment tx_errors)."""
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo tc qdisc replace dev %s root netem corrupt 100%%' % iface)
+        self.addCleanup(self._remove_tc_root, hypervisor_ip, iface)
+
+    def _remove_tc_root(self, hypervisor_ip, iface):
+        self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo tc qdisc del dev %s root 2>/dev/null || true' % iface)
+
+    def _induce_rx_dropped_on_iface(self, hypervisor_ip, iface, peer,
+                                    peer_ip, iface_ip, flood_count, baseline,
+                                    label):
+        """Flood the OVS leg from the host peer; return exporter-mapped delta."""
+        self._hypervisor_ping_flood(
+            hypervisor_ip, peer, iface_ip, flood_count)
+        self._hypervisor_udp_flood(
+            hypervisor_ip, peer, peer_ip, iface_ip, flood_count)
+        after = self._ovs_interface_stats(hypervisor_ip, iface)
+        return self._log_error_induce_stats(label, baseline, after, 'rx_dropped')
+
+    def _induce_veth_rx_dropped(self, hypervisor_ip, iface, peer, peer_ip,
+                                iface_ip, flood_count):
+        """Drop inbound traffic on the OVS port while the host peer stays up."""
+        self._ensure_veth_port_up(hypervisor_ip, iface)
+        baseline = self._ovs_interface_stats(hypervisor_ip, iface)
+
+        self._install_tc_ingress_drop(hypervisor_ip, iface)
+        time.sleep(1)
+        LOG.warning(
+            'Veth rx_dropped induce: tc ingress drop on %s, flood from %s',
+            iface, peer)
+        delta = self._induce_rx_dropped_on_iface(
+            hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
+            baseline, 'Veth RX tc ingress drop')
+        self._remove_tc_ingress(hypervisor_ip, iface)
+
+        if delta <= 0:
+            LOG.warning(
+                'Retrying rx_dropped via OVS admin down on %s', iface)
+            self._set_ovs_admin_db_only(hypervisor_ip, iface, 'down')
+            time.sleep(1)
+            delta = self._induce_rx_dropped_on_iface(
+                hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
+                baseline, 'Veth RX OVS admin down')
+            self._set_ovs_admin_db_only(hypervisor_ip, iface, 'up')
+
+        if delta <= 0:
+            LOG.warning(
+                'Retrying rx_dropped via kernel down on OVS leg %s', iface)
+            self._set_kernel_link_state(hypervisor_ip, iface, 'down')
+            time.sleep(1)
+            delta = self._induce_rx_dropped_on_iface(
+                hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
+                baseline, 'Veth RX kernel down')
+            self._set_kernel_link_state(hypervisor_ip, iface, 'up')
+
+        self._ensure_veth_port_up(hypervisor_ip, iface)
+        if delta <= 0:
+            LOG.warning(
+                'rx_dropped induce finished with delta=0 on %s (baseline=%s)',
+                iface, baseline)
+
+    def _induce_tx_errors_on_iface(self, hypervisor_ip, iface, peer_ip,
+                                   iface_ip, flood_count, baseline, label):
+        """Transmit from the OVS leg toward the host peer address."""
+        self._hypervisor_ping_flood(
+            hypervisor_ip, iface, peer_ip, flood_count)
+        self._hypervisor_udp_flood(
+            hypervisor_ip, iface, iface_ip, peer_ip, flood_count)
+        after = self._ovs_interface_stats(hypervisor_ip, iface)
+        return self._log_error_induce_stats(label, baseline, after, 'tx_errors')
+
+    def _induce_veth_tx_errors(self, hypervisor_ip, iface, peer, iface_ip,
+                               peer_ip, flood_count):
+        """Force TX failures on the OVS leg (peer address is on the host peer)."""
+        self._ensure_veth_port_up(hypervisor_ip, iface)
+        baseline = self._ovs_interface_stats(hypervisor_ip, iface)
+
+        self._set_ovs_admin_db_only(hypervisor_ip, iface, 'down')
+        time.sleep(1)
+        LOG.warning(
+            'Veth tx_errors induce: OVS admin down on %s, transmit to %s',
+            iface, peer_ip)
+        delta = self._induce_tx_errors_on_iface(
+            hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline,
+            'Veth TX OVS admin down')
+        self._set_ovs_admin_db_only(hypervisor_ip, iface, 'up')
+
+        if delta <= 0:
+            LOG.warning(
+                'Retrying tx_errors via peer %s down, transmit from %s',
+                peer, iface)
+            self._ensure_veth_port_up(hypervisor_ip, iface)
+            self._set_kernel_link_state(hypervisor_ip, peer, 'down')
+            time.sleep(1)
+            delta = self._induce_tx_errors_on_iface(
+                hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline,
+                'Veth TX peer down')
+            self._set_kernel_link_state(hypervisor_ip, peer, 'up')
+
+        if delta <= 0:
+            LOG.warning(
+                'Retrying tx_errors via OVS link_state down on %s', iface)
+            self._ensure_veth_port_up(hypervisor_ip, iface)
+            self._ssh_run_on_hypervisor(
+                hypervisor_ip,
+                'sudo ovs-vsctl set Interface %s link_state=down' % iface)
+            time.sleep(1)
+            delta = self._induce_tx_errors_on_iface(
+                hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline,
+                'Veth TX OVS link down')
+            self._ssh_run_on_hypervisor(
+                hypervisor_ip,
+                'sudo ovs-vsctl set Interface %s link_state=up' % iface)
+
+        if delta <= 0:
+            LOG.warning(
+                'Retrying tx_errors via tc netem corrupt on %s', iface)
+            self._ensure_veth_port_up(hypervisor_ip, iface)
+            self._install_tc_egress_corrupt(hypervisor_ip, iface)
+            time.sleep(1)
+            delta = self._induce_tx_errors_on_iface(
+                hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline,
+                'Veth TX tc corrupt')
+            self._remove_tc_root(hypervisor_ip, iface)
+
+        self._ensure_veth_port_up(hypervisor_ip, iface)
+        if delta <= 0:
+            LOG.warning(
+                'tx_errors induce finished with delta=0 on %s (baseline=%s)',
+                iface, baseline)
+
     def _attach_error_test_veth(self, hypervisor_ip, preferred_bridge, iface):
         """Attach disposable veth to the VM bridge or a fallback kernel bridge."""
         self._cleanup_test_interface(hypervisor_ip, iface)
@@ -491,7 +657,6 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         peer = self._veth_peer_name(iface)
         peer_ip = '198.18.99.1'
         iface_ip = '198.18.99.2'
-        remote_ip = '198.18.99.3'
         self._ssh_run_on_hypervisor(
             hypervisor_ip,
             'sudo ip addr add %s/32 dev %s 2>/dev/null || true' % (
@@ -509,39 +674,25 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                     peer_ip, peer, iface_ip, iface))
 
         self.addCleanup(restore_addrs)
-        self._ensure_port_up(hypervisor_ip, iface)
+        self._ensure_veth_port_up(hypervisor_ip, iface)
 
         baseline_rx = self._ovs_interface_stats(hypervisor_ip, iface)
         baseline_rx_prom = self._prom_error_value(
             hypervisor_ip, iface, 'rx_dropped')
-        self._set_ovs_admin_only(hypervisor_ip, iface, 'down')
-        time.sleep(1)
-        LOG.warning(
-            'Veth rx_dropped induce: ping+UDP into admin-down %s on %s:%s',
-            iface, hypervisor_ip, bridge)
-        self._hypervisor_ping_flood(
-            hypervisor_ip, peer, iface_ip, flood_count)
-        self._hypervisor_udp_flood(
-            hypervisor_ip, peer, peer_ip, iface_ip, flood_count)
-        self._ensure_port_up(hypervisor_ip, iface)
+        self._induce_veth_rx_dropped(
+            hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count)
 
         baseline_tx = self._ovs_interface_stats(hypervisor_ip, iface)
         baseline_tx_prom = self._prom_error_value(
             hypervisor_ip, iface, 'tx_errors')
-        self._set_interface_link_state(hypervisor_ip, iface, 'down')
-        time.sleep(1)
-        LOG.warning(
-            'Veth tx_errors induce: ping -I link-down %s on %s:%s',
-            iface, hypervisor_ip, bridge)
-        self._hypervisor_ping_flood(
-            hypervisor_ip, iface, remote_ip, flood_count)
-        self._ensure_port_up(hypervisor_ip, iface)
+        self._induce_veth_tx_errors(
+            hypervisor_ip, iface, peer, iface_ip, peer_ip, flood_count)
 
         after = self._ovs_interface_stats(hypervisor_ip, iface)
         self._log_error_induce_stats(
-            'Veth rx induce', baseline_rx, after, 'rx_dropped')
+            'Veth final rx', baseline_rx, after, 'rx_dropped')
         self._log_error_induce_stats(
-            'Veth tx induce', baseline_tx, after, 'tx_errors')
+            'Veth final tx', baseline_tx, after, 'tx_errors')
 
         veth_ctx = {
             'receiver': {'hypervisor_ip': hypervisor_ip},

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -154,6 +154,77 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             return net['ip_address']
         self.fail('No dataplane IP for VM %s' % server.get('name', server['id']))
 
+    def _dataplane_provider_net(self, server):
+        mgmt_net_id = self._mgmt_network_id()
+        for net in server['provider_networks']:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net
+        for net in server['provider_networks']:
+            return net
+        self.fail(
+            'No dataplane provider network for VM %s' % (
+                server.get('name', server['id'])))
+
+    def _lookup_guest_iface_by_mac(self, ssh_client, mac_address):
+        mac = mac_address.lower()
+        cmd = (
+            "ip -o link | grep -i '%s' | awk -F': ' '{print $2; exit}'" % mac)
+        raw = ssh_client.exec_command(cmd).strip()
+        return raw.split('@')[0].strip() if raw else None
+
+    def _maybe_shrink_guest_rx_ring(self, ssh_client, mac_address):
+        """Temporarily shrink RX ring on guest dataplane NIC to ease RX drops."""
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if not sudo:
+            LOG.warning(
+                'No passwordless sudo on guest; skipping RX ring shrink')
+            return None
+        iface = self._lookup_guest_iface_by_mac(ssh_client, mac_address)
+        if not iface:
+            LOG.warning(
+                'Could not resolve guest iface for MAC %s; skipping RX shrink',
+                mac_address)
+            return None
+        ssh_client.exec_command(
+            '%s ethtool -G %s rx 32 2>/dev/null || '
+            '%s ethtool -G %s rx 64 2>/dev/null || true' % (
+                sudo, iface, sudo, iface))
+
+        def restore():
+            ssh_client.exec_command(
+                '%s ethtool -G %s rx 512 2>/dev/null || true' % (
+                    sudo, iface))
+
+        self.addCleanup(restore)
+        return iface
+
+    def _maybe_shrink_guest_tx_ring(self, ssh_client, mac_address):
+        """Temporarily shrink TX ring on guest dataplane NIC to ease TX drops."""
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if not sudo:
+            LOG.warning(
+                'No passwordless sudo on guest; skipping TX ring shrink')
+            return None
+        iface = self._lookup_guest_iface_by_mac(ssh_client, mac_address)
+        if not iface:
+            LOG.warning(
+                'Could not resolve guest iface for MAC %s; skipping TX shrink',
+                mac_address)
+            return None
+        ssh_client.exec_command(
+            '%s ethtool -G %s tx 32 2>/dev/null || '
+            '%s ethtool -G %s tx 64 2>/dev/null || true' % (
+                sudo, iface, sudo, iface))
+
+        def restore():
+            ssh_client.exec_command(
+                '%s ethtool -G %s tx 512 2>/dev/null || true' % (
+                    sudo, iface))
+
+        self.addCleanup(restore)
+        return iface
+
     def _resolve_ovs_interface(self, server):
         if server.get('other_port'):
             return server['other_port']
@@ -205,7 +276,8 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
     def _assert_error_stat_match_ovs(self, hypervisor_ip, interface,
                                      stat_key, ovs_stats):
         metric_name = metrics_base.OVS_INTERFACE_ERROR_STAT_TO_METRIC[stat_key]
-        ovs_value = self._ovs_interface_stat_int(ovs_stats, stat_key)
+        ovs_value = self._ovs_interface_error_exporter_value(
+            ovs_stats, stat_key)
         prom = self._prom_compute_metric_value(
             hypervisor_ip, metric_name, {'interface': interface})
         storage = self._storage_counter_value(
@@ -263,6 +335,10 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         bind_ip = self._dataplane_bind_ip(sender)
         ssh_sender = self.get_remote_client(
             sender['fip'], self.instance_user, key_pair['private_key'])
+        ssh_receiver = self.get_remote_client(
+            receiver['fip'], self.instance_user, key_pair['private_key'])
+        receiver_net = self._dataplane_provider_net(receiver)
+        sender_net = self._dataplane_provider_net(sender)
         return {
             'sender': sender,
             'receiver': receiver,
@@ -271,10 +347,61 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             'peer_ip': peer_ip,
             'bind_ip': bind_ip,
             'ssh_sender': ssh_sender,
+            'ssh_receiver': ssh_receiver,
+            'receiver_mac': receiver_net['mac_address'],
+            'sender_mac': sender_net['mac_address'],
             'key_pair': key_pair,
         }
 
-    def _wait_for_induced_errors(self, ctx, baseline_receiver, baseline_sender):
+    def _error_counter_delta(self, current_stats, baseline_stats, stat_key):
+        return (
+            self._ovs_interface_error_exporter_value(current_stats, stat_key) -
+            self._ovs_interface_error_exporter_value(baseline_stats, stat_key))
+
+    def _induce_rx_dropped(self, ctx, flood_count):
+        """Shrink receiver RX ring and flood peer to overflow vhost RX queue."""
+        receiver_hyp = ctx['receiver']['hypervisor_ip']
+        baseline = self._ovs_interface_stats(
+            receiver_hyp, ctx['receiver_iface'])
+        self._maybe_shrink_guest_rx_ring(
+            ctx['ssh_receiver'], ctx['receiver_mac'])
+        LOG.warning(
+            'Inducing rx_dropped: %d UDP datagrams %s -> %s (receiver %s:%s)',
+            flood_count, ctx['bind_ip'], ctx['peer_ip'],
+            receiver_hyp, ctx['receiver_iface'])
+        self._flood_udp_dataplane(
+            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+        return baseline
+
+    def _induce_tx_errors(self, ctx, flood_count):
+        """Disable sender OVS link and flood TX to increment failure drops."""
+        sender_hyp = ctx['sender']['hypervisor_ip']
+        sender_iface = ctx['sender_iface']
+        baseline = self._ovs_interface_stats(sender_hyp, sender_iface)
+
+        def restore_sender_iface():
+            self._set_interface_link_state(sender_hyp, sender_iface, 'up')
+            self._set_ovs_admin_only(sender_hyp, sender_iface, 'up')
+
+        self.addCleanup(restore_sender_iface)
+        self._maybe_shrink_guest_tx_ring(
+            ctx['ssh_sender'], ctx['sender_mac'])
+        LOG.warning(
+            'Inducing tx_errors: admin/link down on %s:%s during %d UDP '
+            'datagrams %s -> %s',
+            sender_hyp, sender_iface, flood_count,
+            ctx['bind_ip'], ctx['peer_ip'])
+        self._set_ovs_admin_only(sender_hyp, sender_iface, 'down')
+        self._set_interface_link_state(sender_hyp, sender_iface, 'down')
+        try:
+            self._flood_udp_dataplane(
+                ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+        except Exception as exc:
+            LOG.warning('UDP flood while iface down finished: %s', exc)
+        restore_sender_iface()
+        return baseline
+
+    def _wait_for_induced_errors(self, ctx, baseline_rx, baseline_tx):
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
@@ -282,17 +409,21 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                 ctx['receiver']['hypervisor_ip'], ctx['receiver_iface'])
             sender_stats = self._ovs_interface_stats(
                 ctx['sender']['hypervisor_ip'], ctx['sender_iface'])
-            rx_drop_delta = (
-                self._ovs_interface_stat_int(receiver_stats, 'rx_dropped') -
-                self._ovs_interface_stat_int(baseline_receiver, 'rx_dropped'))
-            tx_err_delta = (
-                self._ovs_interface_stat_int(sender_stats, 'tx_errors') -
-                self._ovs_interface_stat_int(baseline_sender, 'tx_errors'))
+            rx_drop_delta = self._error_counter_delta(
+                receiver_stats, baseline_rx, 'rx_dropped')
+            tx_err_delta = self._error_counter_delta(
+                sender_stats, baseline_tx, 'tx_errors')
             last = {
                 'rx_dropped_delta': rx_drop_delta,
                 'tx_errors_delta': tx_err_delta,
-                'receiver_stats_keys': sorted(receiver_stats.keys()),
-                'sender_stats_keys': sorted(sender_stats.keys()),
+                'receiver_rx_dropped': self._ovs_interface_stat_int(
+                    receiver_stats, 'rx_dropped'),
+                'receiver_rx_missed_errors': self._ovs_interface_stat_int(
+                    receiver_stats, 'rx_missed_errors'),
+                'sender_tx_errors': self._ovs_interface_stat_int(
+                    sender_stats, 'tx_errors'),
+                'sender_ovs_tx_failure_drops': self._ovs_interface_stat_int(
+                    sender_stats, 'ovs_tx_failure_drops'),
             }
             try:
                 self.assertGreater(
@@ -354,44 +485,15 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             raise unittest.SkipTest(
                 'OVS error induce tests currently require IPv4 dataplane peers')
 
-        baseline_receiver = self._ovs_interface_stats(
-            ctx['receiver']['hypervisor_ip'], ctx['receiver_iface'])
-        baseline_sender = self._ovs_interface_stats(
-            ctx['sender']['hypervisor_ip'], ctx['sender_iface'])
-
         self._send_ping_packets(
             ctx['ssh_sender'], ctx['peer_ip'], self._traffic_ping_count(),
             self._min_expected_packets())
 
         flood_count = CONF.nfv_plugin_options.network_exporter_error_udp_flood_packets
-        LOG.warning(
-            'Inducing rx_dropped: %d UDP datagrams %s -> %s',
-            flood_count, ctx['bind_ip'], ctx['peer_ip'])
-        self._flood_udp_dataplane(
-            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+        baseline_rx = self._induce_rx_dropped(ctx, flood_count)
+        baseline_tx = self._induce_tx_errors(ctx, flood_count)
 
-        sender_hyp = ctx['sender']['hypervisor_ip']
-        sender_iface = ctx['sender_iface']
-
-        def restore_sender_iface():
-            self._set_interface_link_state(sender_hyp, sender_iface, 'up')
-            self._set_ovs_admin_only(sender_hyp, sender_iface, 'up')
-
-        self.addCleanup(restore_sender_iface)
-        LOG.warning(
-            'Inducing tx_errors: admin/link down on %s:%s during UDP flood',
-            sender_hyp, sender_iface)
-        self._set_ovs_admin_only(sender_hyp, sender_iface, 'down')
-        self._set_interface_link_state(sender_hyp, sender_iface, 'down')
-        try:
-            self._flood_udp_dataplane(
-                ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], 5000)
-        except Exception as exc:
-            LOG.warning('UDP flood while iface down finished: %s', exc)
-        restore_sender_iface()
-
-        deltas = self._wait_for_induced_errors(
-            ctx, baseline_receiver, baseline_sender)
+        deltas = self._wait_for_induced_errors(ctx, baseline_rx, baseline_tx)
         LOG.warning(
             'OVS error counters OK: rx_dropped +%s rx_dropped_delta, '
             'tx_errors +%s',

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -269,7 +269,8 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         self._set_ovs_admin_only(hypervisor_ip, interface, 'up')
         self._set_interface_link_state(hypervisor_ip, interface, 'up')
 
-    def _log_error_induce_stats(self, label, baseline, current, stat_key):
+    def _log_error_induce_stats(self, label, baseline, current, stat_key,
+                                hypervisor_ip=None, iface=None):
         delta = self._error_counter_delta(current, baseline, stat_key)
         rx_pkts = (
             self._ovs_interface_stat_int(current, 'rx_packets') -
@@ -277,15 +278,21 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         tx_pkts = (
             self._ovs_interface_stat_int(current, 'tx_packets') -
             self._ovs_interface_stat_int(baseline, 'tx_packets'))
+        qos_drops = self._ovs_interface_stat_int(current, 'ovs_rx_qos_drops')
+        kernel_rx_drop = (
+            self._kernel_iface_stat(hypervisor_ip, iface, 'rx_dropped')
+            if hypervisor_ip and iface else None)
         LOG.warning(
             '%s: %s_delta=%s rx_packets_delta=%s tx_packets_delta=%s '
-            'rx_dropped=%s rx_missed_errors=%s tx_errors=%s '
-            'ovs_tx_failure_drops=%s',
+            'rx_dropped=%s rx_missed_errors=%s ovs_rx_qos_drops=%s '
+            'tx_errors=%s ovs_tx_failure_drops=%s kernel_rx_dropped=%s',
             label, stat_key, delta, rx_pkts, tx_pkts,
             self._ovs_interface_stat_int(current, 'rx_dropped'),
             self._ovs_interface_stat_int(current, 'rx_missed_errors'),
+            qos_drops,
             self._ovs_interface_stat_int(current, 'tx_errors'),
-            self._ovs_interface_stat_int(current, 'ovs_tx_failure_drops'))
+            self._ovs_interface_stat_int(current, 'ovs_tx_failure_drops'),
+            kernel_rx_drop)
         return delta
 
     def _resolve_ovs_interface(self, server):
@@ -479,6 +486,71 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                 count, iface, dest_ip))
         self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
 
+    def _hypervisor_peer_rx_flood(self, hypervisor_ip, peer, peer_ip, iface_ip,
+                                  flood_count):
+        """L2/L3 flood into the OVS veth leg from the host peer."""
+        self._hypervisor_udp_flood(
+            hypervisor_ip, peer, peer_ip, iface_ip, flood_count)
+        script = (
+            'import socket\n'
+            'SO_BINDTODEVICE = 25\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            's.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1048576)\n'
+            's.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)\n'
+            's.setsockopt(socket.SOL_SOCKET, SO_BINDTODEVICE, %r)\n'
+            's.bind((%r, 0))\n'
+            'payload = b"x" * 1400\n'
+            'dest = (%r, 9999)\n'
+            'for _ in range(%d):\n'
+            '    try:\n'
+            '        s.sendto(payload, dest)\n'
+            '    except OSError:\n'
+            '        pass\n'
+            % (peer.encode(), peer_ip, '255.255.255.255', flood_count))
+        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
+        cmd = (
+            "sudo timeout 180 sh -c 'echo %s | base64 -d | python3'" % encoded)
+        self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
+
+    def _tc_ingress_drop_count(self, hypervisor_ip, iface):
+        out = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'tc -s filter show dev %s ingress 2>/dev/null' % iface)
+        total = 0
+        for line in out.splitlines():
+            line = line.strip()
+            if not line.startswith('drop'):
+                continue
+            parts = line.split()
+            for idx, part in enumerate(parts):
+                if part == 'drop' and idx + 1 < len(parts):
+                    try:
+                        total += int(parts[idx + 1])
+                    except ValueError:
+                        pass
+        return total
+
+    def _limit_netdev_backlog(self, hypervisor_ip, value):
+        out = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sysctl -n net.core.netdev_max_backlog 2>/dev/null').strip()
+        try:
+            old = int(out)
+        except (TypeError, ValueError):
+            old = 1000
+
+        def restore():
+            self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip,
+                'sudo sysctl -w net.core.netdev_max_backlog=%d 2>/dev/null '
+                '|| true' % old)
+
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo sysctl -w net.core.netdev_max_backlog=%d' % value)
+        self.addCleanup(restore)
+        return old
+
     def _set_ovs_admin_db_only(self, hypervisor_ip, interface, state):
         """Set OVS admin_state only (leave kernel veth legs unchanged)."""
         self._ssh_run_on_hypervisor(
@@ -515,38 +587,48 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             'ingress_policing_burst=0' % interface)
 
     def _try_install_tc_ingress_drop(self, hypervisor_ip, iface):
-        """Install an ingress drop filter; return False when tc is unavailable."""
+        """Install a verified clsact/ingress drop filter on the OVS netdev."""
+        self._remove_tc_ingress(hypervisor_ip, iface)
         self._ssh_run_unchecked_on_hypervisor(
             hypervisor_ip,
-            'sudo modprobe sch_ingress cls_u32 act_gact 2>/dev/null || true')
-        out = self._ssh_run_unchecked_on_hypervisor(
-            hypervisor_ip,
-            'sudo tc qdisc add dev %s handle ffff: ingress 2>&1; '
-            'echo __ingress__:$?' % iface)
-        if '__ingress__:0' not in out and 'exists' not in out.lower():
+            'sudo modprobe clsact act_gact cls_u32 sch_ingress '
+            '2>/dev/null || true')
+        for qdisc_cmd in (
+                'sudo tc qdisc add dev %s clsact' % iface,
+                'sudo tc qdisc add dev %s handle ffff: ingress' % iface):
             out = self._ssh_run_unchecked_on_hypervisor(
-                hypervisor_ip,
-                'sudo tc qdisc add dev %s clsact 2>&1; echo __clsact__:$?' % (
-                    iface))
-            if '__clsact__:0' not in out and 'exists' not in out.lower():
-                LOG.warning(
-                    'tc ingress/clsact unavailable on %s for %s: %s',
-                    hypervisor_ip, iface, out.strip())
-                return False
-        out = self._ssh_run_unchecked_on_hypervisor(
-            hypervisor_ip,
-            'sudo tc filter add dev %s parent ffff: protocol all u32 '
-            'match u32 0 0 action drop 2>&1; echo __filter__:$?' % iface)
-        if '__filter__:0' not in out:
-            out = self._ssh_run_unchecked_on_hypervisor(
-                hypervisor_ip,
+                hypervisor_ip, '%s 2>&1; echo __qdisc__:$?' % qdisc_cmd)
+            if '__qdisc__:0' in out or 'exists' in out.lower():
+                break
+        else:
+            LOG.warning(
+                'tc clsact/ingress qdisc unavailable on %s for %s',
+                hypervisor_ip, iface)
+            return False
+        for filter_cmd in (
                 'sudo tc filter add dev %s ingress protocol all u32 '
-                'match u32 0 0 action drop 2>&1; echo __filter__:$?' % iface)
-            if '__filter__:0' not in out:
-                LOG.warning(
-                    'tc ingress drop filter unavailable on %s for %s: %s',
-                    hypervisor_ip, iface, out.strip())
-                return False
+                'match u32 0 0 action drop' % iface,
+                'sudo tc filter add dev %s parent ffff: protocol all u32 '
+                'match u32 0 0 action drop' % iface):
+            out = self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip, '%s 2>&1; echo __filter__:$?' % filter_cmd)
+            if '__filter__:0' in out:
+                break
+        else:
+            LOG.warning(
+                'tc ingress drop filter unavailable on %s for %s: %s',
+                hypervisor_ip, iface, out.strip())
+            self._remove_tc_ingress(hypervisor_ip, iface)
+            return False
+        verify = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'tc filter show dev %s ingress 2>/dev/null' % iface)
+        if 'action drop' not in verify and 'gact action drop' not in verify:
+            LOG.warning(
+                'tc ingress drop filter missing on %s for %s: %s',
+                hypervisor_ip, iface, verify.strip())
+            self._remove_tc_ingress(hypervisor_ip, iface)
+            return False
         self.addCleanup(self._remove_tc_ingress, hypervisor_ip, iface)
         return True
 
@@ -611,36 +693,26 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                                     peer_ip, iface_ip, flood_count, baseline,
                                     label, vm_ctx=None):
         """Flood the OVS leg from the host peer; return exporter-mapped delta."""
-        self._hypervisor_ping_flood(
-            hypervisor_ip, peer, iface_ip, flood_count)
-        self._hypervisor_udp_flood(
+        self._hypervisor_peer_rx_flood(
             hypervisor_ip, peer, peer_ip, iface_ip, flood_count)
         if vm_ctx:
             self._flood_udp_dataplane(
                 vm_ctx['ssh_sender'], vm_ctx['bind_ip'], iface_ip,
                 flood_count)
         after = self._ovs_interface_stats(hypervisor_ip, iface)
-        return self._log_error_induce_stats(label, baseline, after, 'rx_dropped')
+        return self._log_error_induce_stats(
+            label, baseline, after, 'rx_dropped',
+            hypervisor_ip=hypervisor_ip, iface=iface)
 
     def _induce_veth_rx_dropped(self, hypervisor_ip, iface, peer, peer_ip,
                                 iface_ip, flood_count, vm_ctx=None):
         """Drop inbound traffic on the OVS port while the host peer stays up."""
         self._ensure_veth_port_up(hypervisor_ip, iface)
         baseline = self._ovs_interface_stats(hypervisor_ip, iface)
+        delta = 0
 
-        self._set_ovs_ingress_policing(hypervisor_ip, iface, 100, 10)
-        self.addCleanup(self._clear_ovs_ingress_policing, hypervisor_ip, iface)
-        time.sleep(1)
-        LOG.warning(
-            'Veth rx_dropped induce: OVS ingress policing on %s, flood from %s',
-            iface, peer)
-        delta = self._induce_rx_dropped_on_iface(
-            hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
-            baseline, 'Veth RX OVS policing', vm_ctx=vm_ctx)
-        self._clear_ovs_ingress_policing(hypervisor_ip, iface)
-
-        if delta <= 0 and self._try_install_tc_ingress_drop(
-                hypervisor_ip, iface):
+        if self._try_install_tc_ingress_drop(hypervisor_ip, iface):
+            tc_before = self._tc_ingress_drop_count(hypervisor_ip, iface)
             time.sleep(1)
             LOG.warning(
                 'Veth rx_dropped induce: tc ingress drop on %s, flood from %s',
@@ -648,7 +720,26 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             delta = self._induce_rx_dropped_on_iface(
                 hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
                 baseline, 'Veth RX tc ingress drop', vm_ctx=vm_ctx)
+            tc_after = self._tc_ingress_drop_count(hypervisor_ip, iface)
+            LOG.warning(
+                'tc ingress drop counter on %s: before=%s after=%s',
+                iface, tc_before, tc_after)
             self._remove_tc_ingress(hypervisor_ip, iface)
+
+        if delta <= 0:
+            LOG.warning(
+                'Retrying rx_dropped via netdev backlog pressure on %s', iface)
+            self._limit_netdev_backlog(hypervisor_ip, 10)
+            self._ssh_run_on_hypervisor(
+                hypervisor_ip,
+                'sudo ip link set dev %s txqueuelen 1' % iface)
+            time.sleep(1)
+            delta = self._induce_rx_dropped_on_iface(
+                hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
+                baseline, 'Veth RX backlog pressure', vm_ctx=vm_ctx)
+            self._ssh_run_on_hypervisor(
+                hypervisor_ip,
+                'sudo ip link set dev %s txqueuelen 1000' % iface)
 
         if delta <= 0:
             LOG.warning(
@@ -674,9 +765,12 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         if delta <= 0:
             LOG.warning(
                 'rx_dropped induce finished with delta=0 on %s '
-                '(baseline=%s kernel_rx_dropped=%s)',
+                '(baseline=%s kernel_rx_dropped=%s ovs_rx_qos_drops=%s)',
                 iface, baseline,
-                self._kernel_iface_stat(hypervisor_ip, iface, 'rx_dropped'))
+                self._kernel_iface_stat(hypervisor_ip, iface, 'rx_dropped'),
+                self._ovs_interface_stat_int(
+                    self._ovs_interface_stats(hypervisor_ip, iface),
+                    'ovs_rx_qos_drops'))
 
     def _induce_tx_errors_on_iface(self, hypervisor_ip, iface, peer_ip,
                                    iface_ip, flood_count, baseline, label,

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -14,7 +14,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import base64
 import time
 import unittest
 
@@ -174,6 +173,26 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         raw = ssh_client.exec_command(cmd).strip()
         return raw.split('@')[0].strip() if raw else None
 
+    def _set_guest_iface_link(self, ssh_client, mac_address, state):
+        """Bring guest dataplane netdev up or down."""
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if not sudo:
+            LOG.warning(
+                'No passwordless sudo on guest; cannot set dataplane link %s',
+                state)
+            return False
+        iface = self._lookup_guest_iface_by_mac(ssh_client, mac_address)
+        if not iface:
+            LOG.warning(
+                'Could not resolve guest iface for MAC %s', mac_address)
+            return False
+        ssh_client.exec_command(
+            '%s ip link set dev %s %s' % (sudo, iface, state))
+        return True
+
+    def _restore_guest_iface_link(self, ssh_client, mac_address):
+        self._set_guest_iface_link(ssh_client, mac_address, 'up')
+
     def _maybe_shrink_guest_rx_ring(self, ssh_client, mac_address):
         """Temporarily shrink RX ring on guest dataplane NIC to ease RX drops."""
         sudo = self._guest_sudo_prefix(ssh_client)
@@ -247,34 +266,6 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             return
         self._set_ovs_admin_only(hypervisor_ip, interface, 'up')
         self._set_interface_link_state(hypervisor_ip, interface, 'up')
-
-    def _start_guest_udp_blackhole(self, ssh_client, port=9999):
-        """Bind UDP on the guest but never recv, to fill the vhost RX virtqueue."""
-        script = (
-            'import socket, time\n'
-            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
-            's.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)\n'
-            's.bind(("0.0.0.0", %d))\n'
-            'while True:\n'
-            '    time.sleep(3600)\n' % port)
-        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
-        cmd = (
-            "nohup sh -c 'echo %s | base64 -d | python3' "
-            ">/tmp/ovs_error_udp_blackhole.log 2>&1 & echo $!" % encoded)
-        sudo = self._guest_sudo_prefix(ssh_client)
-        if sudo:
-            cmd = '%s %s' % (sudo, cmd)
-        pid = ssh_client.exec_command(cmd).strip()
-        time.sleep(1)
-        self.addCleanup(self._stop_guest_udp_blackhole, ssh_client, pid)
-        return pid
-
-    def _stop_guest_udp_blackhole(self, ssh_client, pid):
-        try:
-            ssh_client.exec_command('kill %s 2>/dev/null || true' % pid)
-        except Exception as exc:
-            LOG.warning(
-                'Failed to stop guest UDP blackhole pid %s: %s', pid, exc)
 
     def _log_error_induce_stats(self, label, baseline, current, stat_key):
         delta = self._error_counter_delta(current, baseline, stat_key)
@@ -430,92 +421,109 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             self._ovs_interface_error_exporter_value(baseline_stats, stat_key))
 
     def _induce_rx_dropped(self, ctx, flood_count):
-        """Fill receiver vhost RX virtqueue, then block OVS RX if needed."""
+        """Drop guest->OVS traffic on the receiver vhost-user port.
+
+        On vhu* ports rx_dropped counts packets received from the guest that
+        OVS could not accept. Flood from the receiver guest while its OVS
+        port is constrained.
+        """
         receiver_hyp = ctx['receiver']['hypervisor_ip']
         receiver_iface = ctx['receiver_iface']
+        receiver_bind = self._dataplane_bind_ip(ctx['receiver'])
         baseline = self._ovs_interface_stats(receiver_hyp, receiver_iface)
 
-        self._start_guest_udp_blackhole(ctx['ssh_receiver'])
-        self._maybe_shrink_guest_rx_ring(
+        self.addCleanup(self._restore_ovs_interface, receiver_hyp, receiver_iface)
+        self._maybe_shrink_guest_tx_ring(
             ctx['ssh_receiver'], ctx['receiver_mac'])
+
+        self._set_ovs_oper_state(
+            receiver_hyp, receiver_iface, 'up', 'down')
+        time.sleep(1)
         LOG.warning(
-            'Inducing rx_dropped: blackhole + %d UDP datagrams %s -> %s '
-            '(receiver %s:%s)',
-            flood_count, ctx['bind_ip'], ctx['peer_ip'],
-            receiver_hyp, receiver_iface)
+            'Inducing rx_dropped: receiver guest flood %s -> %s with OVS '
+            'link down on %s:%s',
+            receiver_bind, ctx['bind_ip'], receiver_hyp, receiver_iface)
         self._flood_udp_dataplane(
-            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+            ctx['ssh_receiver'], receiver_bind, ctx['bind_ip'], flood_count)
         after = self._ovs_interface_stats(receiver_hyp, receiver_iface)
         delta = self._log_error_induce_stats(
-            'RX induce blackhole', baseline, after, 'rx_dropped')
+            'RX induce receiver guest flood + OVS link down', baseline, after,
+            'rx_dropped')
 
         if delta <= 0:
             LOG.warning(
-                'Retrying rx_dropped induce: receiver OVS link down on %s:%s',
-                receiver_hyp, receiver_iface)
+                'Retrying rx_dropped: receiver admin+link down during guest '
+                'flood')
             self._set_ovs_oper_state(
-                receiver_hyp, receiver_iface, 'up', 'down')
-            self.addCleanup(
-                self._restore_ovs_interface, receiver_hyp, receiver_iface)
+                receiver_hyp, receiver_iface, 'down', 'down')
             time.sleep(1)
             self._flood_udp_dataplane(
-                ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+                ctx['ssh_receiver'], receiver_bind, ctx['bind_ip'], flood_count)
             after = self._ovs_interface_stats(receiver_hyp, receiver_iface)
             self._log_error_induce_stats(
-                'RX induce receiver link down', baseline, after, 'rx_dropped')
-            self._restore_ovs_interface(receiver_hyp, receiver_iface)
+                'RX induce receiver guest flood + OVS admin down', baseline,
+                after, 'rx_dropped')
+
+        self._restore_ovs_interface(receiver_hyp, receiver_iface)
         return baseline
 
     def _induce_tx_errors(self, ctx, flood_count):
-        """Block sender vhost-user oper state while guest keeps transmitting."""
+        """Drop OVS->guest delivery on the sender vhost-user port.
+
+        ovs_interface_tx_errors maps to ovs_tx_failure_drops on vhu* ports,
+        which counts packets OVS could not deliver to the guest. Flood to
+        the sender from the receiver while the sender guest cannot receive.
+        """
         sender_hyp = ctx['sender']['hypervisor_ip']
         sender_iface = ctx['sender_iface']
+        receiver_bind = self._dataplane_bind_ip(ctx['receiver'])
         baseline = self._ovs_interface_stats(sender_hyp, sender_iface)
-        vhost = self._is_vhostuser_interface(sender_hyp, sender_iface)
 
+        self.addCleanup(self._restore_guest_iface_link,
+                        ctx['ssh_sender'], ctx['sender_mac'])
         self.addCleanup(self._restore_ovs_interface, sender_hyp, sender_iface)
-        self._maybe_shrink_guest_tx_ring(
-            ctx['ssh_sender'], ctx['sender_mac'])
 
-        if vhost:
-            self._set_ovs_oper_state(
-                sender_hyp, sender_iface, 'up', 'down')
-        else:
-            self._set_interface_link_state(sender_hyp, sender_iface, 'down')
+        guest_down = self._set_guest_iface_link(
+            ctx['ssh_sender'], ctx['sender_mac'], 'down')
         time.sleep(1)
         LOG.warning(
-            'Inducing tx_errors: sender blocked during %d UDP datagrams '
-            '%s -> %s (%s:%s vhost=%s)',
-            flood_count, ctx['bind_ip'], ctx['peer_ip'],
-            sender_hyp, sender_iface, vhost)
+            'Inducing tx_errors: receiver flood %s -> %s with sender guest '
+            'down (guest_down=%s)',
+            receiver_bind, ctx['bind_ip'], guest_down)
         try:
             self._flood_udp_dataplane(
-                ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+                ctx['ssh_receiver'], receiver_bind, ctx['bind_ip'],
+                flood_count)
         except Exception as exc:
-            LOG.warning('UDP flood while sender blocked finished: %s', exc)
+            LOG.warning('Receiver flood toward sender finished: %s', exc)
         after = self._ovs_interface_stats(sender_hyp, sender_iface)
         delta = self._log_error_induce_stats(
-            'TX induce link down', baseline, after, 'tx_errors')
+            'TX induce sender guest down', baseline, after, 'tx_errors')
 
-        if delta <= 0 and vhost:
+        if delta <= 0:
             LOG.warning(
-                'Retrying tx_errors induce: sender admin+link down on %s:%s',
-                sender_hyp, sender_iface)
+                'Retrying tx_errors: sender OVS link down during receiver flood')
+            self._restore_guest_iface_link(
+                ctx['ssh_sender'], ctx['sender_mac'])
+            time.sleep(1)
             self._set_ovs_oper_state(
-                sender_hyp, sender_iface, 'down', 'down')
+                sender_hyp, sender_iface, 'up', 'down')
             time.sleep(1)
             try:
                 self._flood_udp_dataplane(
-                    ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
+                    ctx['ssh_receiver'], receiver_bind, ctx['bind_ip'],
                     flood_count)
             except Exception as exc:
                 LOG.warning(
-                    'UDP flood while sender admin down finished: %s', exc)
+                    'Receiver flood with sender OVS down finished: %s', exc)
             after = self._ovs_interface_stats(sender_hyp, sender_iface)
             self._log_error_induce_stats(
-                'TX induce admin down', baseline, after, 'tx_errors')
+                'TX induce sender OVS link down', baseline, after, 'tx_errors')
+            self._restore_ovs_interface(sender_hyp, sender_iface)
+        else:
+            self._restore_guest_iface_link(
+                ctx['ssh_sender'], ctx['sender_mac'])
 
-        self._restore_ovs_interface(sender_hyp, sender_iface)
         return baseline
 
     def _wait_for_induced_errors(self, ctx, baseline_rx, baseline_tx):
@@ -537,10 +545,14 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                     receiver_stats, 'rx_dropped'),
                 'receiver_rx_missed_errors': self._ovs_interface_stat_int(
                     receiver_stats, 'rx_missed_errors'),
+                'receiver_ovs_rx_qos_drops': self._ovs_interface_stat_int(
+                    receiver_stats, 'ovs_rx_qos_drops'),
                 'sender_tx_errors': self._ovs_interface_stat_int(
                     sender_stats, 'tx_errors'),
                 'sender_ovs_tx_failure_drops': self._ovs_interface_stat_int(
                     sender_stats, 'ovs_tx_failure_drops'),
+                'sender_tx_dropped': self._ovs_interface_stat_int(
+                    sender_stats, 'tx_dropped'),
             }
             try:
                 self.assertGreater(

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import base64
 import time
 import unittest
 
@@ -225,6 +226,75 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         self.addCleanup(restore)
         return iface
 
+    def _is_vhostuser_interface(self, hypervisor_ip, interface):
+        if interface.startswith('vhu'):
+            return True
+        itype = self._ovs_field(hypervisor_ip, interface, 'type') or ''
+        itype = itype.lower()
+        return 'vhost' in itype or 'dpdkvhost' in itype
+
+    def _set_ovs_oper_state(self, hypervisor_ip, interface, admin, link):
+        """Set OVS admin/link via OVSDB (required for vhost-user VM ports)."""
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo ovs-vsctl set Interface %s admin_state=%s link_state=%s' % (
+                interface, admin, link))
+
+    def _restore_ovs_interface(self, hypervisor_ip, interface):
+        if self._is_vhostuser_interface(hypervisor_ip, interface):
+            self._set_ovs_oper_state(
+                hypervisor_ip, interface, 'up', 'up')
+            return
+        self._set_ovs_admin_only(hypervisor_ip, interface, 'up')
+        self._set_interface_link_state(hypervisor_ip, interface, 'up')
+
+    def _start_guest_udp_blackhole(self, ssh_client, port=9999):
+        """Bind UDP on the guest but never recv, to fill the vhost RX virtqueue."""
+        script = (
+            'import socket, time\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            's.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)\n'
+            's.bind(("0.0.0.0", %d))\n'
+            'while True:\n'
+            '    time.sleep(3600)\n' % port)
+        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
+        cmd = (
+            "nohup sh -c 'echo %s | base64 -d | python3' "
+            ">/tmp/ovs_error_udp_blackhole.log 2>&1 & echo $!" % encoded)
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if sudo:
+            cmd = '%s %s' % (sudo, cmd)
+        pid = ssh_client.exec_command(cmd).strip()
+        time.sleep(1)
+        self.addCleanup(self._stop_guest_udp_blackhole, ssh_client, pid)
+        return pid
+
+    def _stop_guest_udp_blackhole(self, ssh_client, pid):
+        try:
+            ssh_client.exec_command('kill %s 2>/dev/null || true' % pid)
+        except Exception as exc:
+            LOG.warning(
+                'Failed to stop guest UDP blackhole pid %s: %s', pid, exc)
+
+    def _log_error_induce_stats(self, label, baseline, current, stat_key):
+        delta = self._error_counter_delta(current, baseline, stat_key)
+        rx_pkts = (
+            self._ovs_interface_stat_int(current, 'rx_packets') -
+            self._ovs_interface_stat_int(baseline, 'rx_packets'))
+        tx_pkts = (
+            self._ovs_interface_stat_int(current, 'tx_packets') -
+            self._ovs_interface_stat_int(baseline, 'tx_packets'))
+        LOG.warning(
+            '%s: %s_delta=%s rx_packets_delta=%s tx_packets_delta=%s '
+            'rx_dropped=%s rx_missed_errors=%s tx_errors=%s '
+            'ovs_tx_failure_drops=%s',
+            label, stat_key, delta, rx_pkts, tx_pkts,
+            self._ovs_interface_stat_int(current, 'rx_dropped'),
+            self._ovs_interface_stat_int(current, 'rx_missed_errors'),
+            self._ovs_interface_stat_int(current, 'tx_errors'),
+            self._ovs_interface_stat_int(current, 'ovs_tx_failure_drops'))
+        return delta
+
     def _resolve_ovs_interface(self, server):
         if server.get('other_port'):
             return server['other_port']
@@ -303,6 +373,7 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         script = (
             'import socket\n'
             's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            's.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1048576)\n'
             's.bind((%r, 0))\n'
             'payload = b"x" * 1400\n'
             'dest = (%r, 9999)\n'
@@ -359,46 +430,92 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             self._ovs_interface_error_exporter_value(baseline_stats, stat_key))
 
     def _induce_rx_dropped(self, ctx, flood_count):
-        """Shrink receiver RX ring and flood peer to overflow vhost RX queue."""
+        """Fill receiver vhost RX virtqueue, then block OVS RX if needed."""
         receiver_hyp = ctx['receiver']['hypervisor_ip']
-        baseline = self._ovs_interface_stats(
-            receiver_hyp, ctx['receiver_iface'])
+        receiver_iface = ctx['receiver_iface']
+        baseline = self._ovs_interface_stats(receiver_hyp, receiver_iface)
+
+        self._start_guest_udp_blackhole(ctx['ssh_receiver'])
         self._maybe_shrink_guest_rx_ring(
             ctx['ssh_receiver'], ctx['receiver_mac'])
         LOG.warning(
-            'Inducing rx_dropped: %d UDP datagrams %s -> %s (receiver %s:%s)',
+            'Inducing rx_dropped: blackhole + %d UDP datagrams %s -> %s '
+            '(receiver %s:%s)',
             flood_count, ctx['bind_ip'], ctx['peer_ip'],
-            receiver_hyp, ctx['receiver_iface'])
+            receiver_hyp, receiver_iface)
         self._flood_udp_dataplane(
             ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+        after = self._ovs_interface_stats(receiver_hyp, receiver_iface)
+        delta = self._log_error_induce_stats(
+            'RX induce blackhole', baseline, after, 'rx_dropped')
+
+        if delta <= 0:
+            LOG.warning(
+                'Retrying rx_dropped induce: receiver OVS link down on %s:%s',
+                receiver_hyp, receiver_iface)
+            self._set_ovs_oper_state(
+                receiver_hyp, receiver_iface, 'up', 'down')
+            self.addCleanup(
+                self._restore_ovs_interface, receiver_hyp, receiver_iface)
+            time.sleep(1)
+            self._flood_udp_dataplane(
+                ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+            after = self._ovs_interface_stats(receiver_hyp, receiver_iface)
+            self._log_error_induce_stats(
+                'RX induce receiver link down', baseline, after, 'rx_dropped')
+            self._restore_ovs_interface(receiver_hyp, receiver_iface)
         return baseline
 
     def _induce_tx_errors(self, ctx, flood_count):
-        """Disable sender OVS link and flood TX to increment failure drops."""
+        """Block sender vhost-user oper state while guest keeps transmitting."""
         sender_hyp = ctx['sender']['hypervisor_ip']
         sender_iface = ctx['sender_iface']
         baseline = self._ovs_interface_stats(sender_hyp, sender_iface)
+        vhost = self._is_vhostuser_interface(sender_hyp, sender_iface)
 
-        def restore_sender_iface():
-            self._set_interface_link_state(sender_hyp, sender_iface, 'up')
-            self._set_ovs_admin_only(sender_hyp, sender_iface, 'up')
-
-        self.addCleanup(restore_sender_iface)
+        self.addCleanup(self._restore_ovs_interface, sender_hyp, sender_iface)
         self._maybe_shrink_guest_tx_ring(
             ctx['ssh_sender'], ctx['sender_mac'])
+
+        if vhost:
+            self._set_ovs_oper_state(
+                sender_hyp, sender_iface, 'up', 'down')
+        else:
+            self._set_interface_link_state(sender_hyp, sender_iface, 'down')
+        time.sleep(1)
         LOG.warning(
-            'Inducing tx_errors: admin/link down on %s:%s during %d UDP '
-            'datagrams %s -> %s',
-            sender_hyp, sender_iface, flood_count,
-            ctx['bind_ip'], ctx['peer_ip'])
-        self._set_ovs_admin_only(sender_hyp, sender_iface, 'down')
-        self._set_interface_link_state(sender_hyp, sender_iface, 'down')
+            'Inducing tx_errors: sender blocked during %d UDP datagrams '
+            '%s -> %s (%s:%s vhost=%s)',
+            flood_count, ctx['bind_ip'], ctx['peer_ip'],
+            sender_hyp, sender_iface, vhost)
         try:
             self._flood_udp_dataplane(
                 ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
         except Exception as exc:
-            LOG.warning('UDP flood while iface down finished: %s', exc)
-        restore_sender_iface()
+            LOG.warning('UDP flood while sender blocked finished: %s', exc)
+        after = self._ovs_interface_stats(sender_hyp, sender_iface)
+        delta = self._log_error_induce_stats(
+            'TX induce link down', baseline, after, 'tx_errors')
+
+        if delta <= 0 and vhost:
+            LOG.warning(
+                'Retrying tx_errors induce: sender admin+link down on %s:%s',
+                sender_hyp, sender_iface)
+            self._set_ovs_oper_state(
+                sender_hyp, sender_iface, 'down', 'down')
+            time.sleep(1)
+            try:
+                self._flood_udp_dataplane(
+                    ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
+                    flood_count)
+            except Exception as exc:
+                LOG.warning(
+                    'UDP flood while sender admin down finished: %s', exc)
+            after = self._ovs_interface_stats(sender_hyp, sender_iface)
+            self._log_error_induce_stats(
+                'TX induce admin down', baseline, after, 'tx_errors')
+
+        self._restore_ovs_interface(sender_hyp, sender_iface)
         return baseline
 
     def _wait_for_induced_errors(self, ctx, baseline_rx, baseline_tx):

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -205,7 +205,7 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
     def _assert_error_stat_match_ovs(self, hypervisor_ip, interface,
                                      stat_key, ovs_stats):
         metric_name = metrics_base.OVS_INTERFACE_ERROR_STAT_TO_METRIC[stat_key]
-        ovs_value = int(ovs_stats[stat_key])
+        ovs_value = self._ovs_interface_stat_int(ovs_stats, stat_key)
         prom = self._prom_compute_metric_value(
             hypervisor_ip, metric_name, {'interface': interface})
         storage = self._storage_counter_value(
@@ -283,14 +283,16 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             sender_stats = self._ovs_interface_stats(
                 ctx['sender']['hypervisor_ip'], ctx['sender_iface'])
             rx_drop_delta = (
-                int(receiver_stats['rx_dropped']) -
-                int(baseline_receiver['rx_dropped']))
+                self._ovs_interface_stat_int(receiver_stats, 'rx_dropped') -
+                self._ovs_interface_stat_int(baseline_receiver, 'rx_dropped'))
             tx_err_delta = (
-                int(sender_stats['tx_errors']) -
-                int(baseline_sender['tx_errors']))
+                self._ovs_interface_stat_int(sender_stats, 'tx_errors') -
+                self._ovs_interface_stat_int(baseline_sender, 'tx_errors'))
             last = {
                 'rx_dropped_delta': rx_drop_delta,
                 'tx_errors_delta': tx_err_delta,
+                'receiver_stats_keys': sorted(receiver_stats.keys()),
+                'sender_stats_keys': sorted(sender_stats.keys()),
             }
             try:
                 self.assertGreater(
@@ -371,20 +373,22 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         sender_hyp = ctx['sender']['hypervisor_ip']
         sender_iface = ctx['sender_iface']
 
-        def restore_admin():
+        def restore_sender_iface():
+            self._set_interface_link_state(sender_hyp, sender_iface, 'up')
             self._set_ovs_admin_only(sender_hyp, sender_iface, 'up')
 
-        self.addCleanup(restore_admin)
+        self.addCleanup(restore_sender_iface)
         LOG.warning(
-            'Inducing tx_errors: admin_state=down on %s:%s during ping',
+            'Inducing tx_errors: admin/link down on %s:%s during UDP flood',
             sender_hyp, sender_iface)
         self._set_ovs_admin_only(sender_hyp, sender_iface, 'down')
+        self._set_interface_link_state(sender_hyp, sender_iface, 'down')
         try:
-            self._send_ping_packets(
-                ctx['ssh_sender'], ctx['peer_ip'], 100, 1)
+            self._flood_udp_dataplane(
+                ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], 5000)
         except Exception as exc:
-            LOG.warning('Expected ping failure while iface down: %s', exc)
-        self._set_ovs_admin_only(sender_hyp, sender_iface, 'up')
+            LOG.warning('UDP flood while iface down finished: %s', exc)
+        restore_sender_iface()
 
         deltas = self._wait_for_induced_errors(
             ctx, baseline_receiver, baseline_sender)

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import base64
 import time
 import unittest
 
@@ -24,6 +25,7 @@ from oslo_log import log as logging
 
 CONF = config.CONF
 LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+ERROR_VETH_IFACE = 'tpst-ovs-er'
 
 
 class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
@@ -420,124 +422,283 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             self._ovs_interface_error_exporter_value(current_stats, stat_key) -
             self._ovs_interface_error_exporter_value(baseline_stats, stat_key))
 
-    def _induce_rx_dropped(self, ctx, flood_count):
-        """Drop guest->OVS traffic on the receiver vhost-user port.
+    def _vm_instance_name(self, server):
+        return self.os_admin.servers_client.show_server(
+            server['id'])['server']['OS-EXT-SRV-ATTR:instance_name']
 
-        On vhu* ports rx_dropped counts packets received from the guest that
-        OVS could not accept. Flood from the receiver guest while its OVS
-        port is constrained.
-        """
-        receiver_hyp = ctx['receiver']['hypervisor_ip']
-        receiver_iface = ctx['receiver_iface']
-        receiver_bind = self._dataplane_bind_ip(ctx['receiver'])
-        baseline = self._ovs_interface_stats(receiver_hyp, receiver_iface)
+    def _hypervisor_domif_link(self, hypervisor_ip, instance_name,
+                               mac_address, state):
+        """Toggle guest NIC link from the compute hypervisor via virsh."""
+        cmd = (
+            'sudo virsh -c qemu:///system domif-setlink %s %s %s' % (
+                instance_name, mac_address, state))
+        self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
 
-        self.addCleanup(self._restore_ovs_interface, receiver_hyp, receiver_iface)
-        self._maybe_shrink_guest_tx_ring(
-            ctx['ssh_receiver'], ctx['receiver_mac'])
-
-        self._set_ovs_oper_state(
-            receiver_hyp, receiver_iface, 'up', 'down')
-        time.sleep(1)
-        LOG.warning(
-            'Inducing rx_dropped: receiver guest flood %s -> %s with OVS '
-            'link down on %s:%s',
-            receiver_bind, ctx['bind_ip'], receiver_hyp, receiver_iface)
-        self._flood_udp_dataplane(
-            ctx['ssh_receiver'], receiver_bind, ctx['bind_ip'], flood_count)
-        after = self._ovs_interface_stats(receiver_hyp, receiver_iface)
-        delta = self._log_error_induce_stats(
-            'RX induce receiver guest flood + OVS link down', baseline, after,
-            'rx_dropped')
-
-        if delta <= 0:
+    def _restore_hypervisor_domif_link(self, hypervisor_ip, instance_name,
+                                       mac_address):
+        try:
+            self._hypervisor_domif_link(
+                hypervisor_ip, instance_name, mac_address, 'up')
+        except Exception as exc:
             LOG.warning(
-                'Retrying rx_dropped: receiver admin+link down during guest '
-                'flood')
-            self._set_ovs_oper_state(
-                receiver_hyp, receiver_iface, 'down', 'down')
-            time.sleep(1)
-            self._flood_udp_dataplane(
-                ctx['ssh_receiver'], receiver_bind, ctx['bind_ip'], flood_count)
-            after = self._ovs_interface_stats(receiver_hyp, receiver_iface)
-            self._log_error_induce_stats(
-                'RX induce receiver guest flood + OVS admin down', baseline,
-                after, 'rx_dropped')
+                'Failed to restore domif link for %s on %s: %s',
+                mac_address, hypervisor_ip, exc)
 
-        self._restore_ovs_interface(receiver_hyp, receiver_iface)
-        return baseline
+    def _prom_error_value(self, hypervisor_ip, interface, stat_key):
+        metric_name = metrics_base.OVS_INTERFACE_ERROR_STAT_TO_METRIC[stat_key]
+        return self._prom_compute_metric_value(
+            hypervisor_ip, metric_name, {'interface': interface})
 
-    def _induce_tx_errors(self, ctx, flood_count):
-        """Drop OVS->guest delivery on the sender vhost-user port.
+    def _error_progress(self, baseline_stats, current_stats, baseline_prom,
+                        current_prom, stat_key):
+        return max(
+            self._error_counter_delta(current_stats, baseline_stats, stat_key),
+            (current_prom or 0) - (baseline_prom or 0))
 
-        ovs_interface_tx_errors maps to ovs_tx_failure_drops on vhu* ports,
-        which counts packets OVS could not deliver to the guest. Flood to
-        the sender from the receiver while the sender guest cannot receive.
-        """
+    def _hypervisor_udp_flood(self, hypervisor_ip, bind_iface, src_ip,
+                              dst_ip, packet_count, port=9999):
+        """Send a UDP flood from the hypervisor (for disposable veth tests)."""
+        script = (
+            'import socket\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            's.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1048576)\n'
+            's.bind((%r, 0))\n'
+            'payload = b"x" * 1400\n'
+            'dest = (%r, %d)\n'
+            'for _ in range(%d):\n'
+            '    try:\n'
+            '        s.sendto(payload, dest)\n'
+            '    except OSError:\n'
+            '        pass\n'
+            % (src_ip, dst_ip, port, packet_count))
+        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
+        cmd = (
+            "sudo timeout 180 sh -c 'echo %s | base64 -d | python3'" % encoded)
+        self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
+
+    def _run_vm_error_induces(self, ctx, flood_count):
+        """Try several VM traffic patterns; return baselines and success."""
+        receiver_hyp = ctx['receiver']['hypervisor_ip']
         sender_hyp = ctx['sender']['hypervisor_ip']
+        receiver_iface = ctx['receiver_iface']
         sender_iface = ctx['sender_iface']
         receiver_bind = self._dataplane_bind_ip(ctx['receiver'])
-        baseline = self._ovs_interface_stats(sender_hyp, sender_iface)
+        receiver_inst = self._vm_instance_name(ctx['receiver'])
+        sender_inst = self._vm_instance_name(ctx['sender'])
 
-        self.addCleanup(self._restore_guest_iface_link,
-                        ctx['ssh_sender'], ctx['sender_mac'])
-        self.addCleanup(self._restore_ovs_interface, sender_hyp, sender_iface)
+        baseline_rx = self._ovs_interface_stats(receiver_hyp, receiver_iface)
+        baseline_tx = self._ovs_interface_stats(sender_hyp, sender_iface)
+        baseline_rx_prom = self._prom_error_value(
+            receiver_hyp, receiver_iface, 'rx_dropped')
+        baseline_tx_prom = self._prom_error_value(
+            sender_hyp, sender_iface, 'tx_errors')
 
-        guest_down = self._set_guest_iface_link(
-            ctx['ssh_sender'], ctx['sender_mac'], 'down')
+        rx_strategies = (
+            'virsh receiver down + sender flood',
+            'guest receiver down + sender flood',
+            'receiver OVS down + sender flood',
+        )
+        tx_strategies = (
+            'virsh sender down + receiver flood',
+            'guest sender down + receiver flood',
+            'sender OVS link down + sender flood',
+        )
+
+        rx_ok = False
+        for name in rx_strategies:
+            LOG.warning('Trying rx_dropped induce: %s', name)
+            try:
+                if name.startswith('virsh receiver'):
+                    try:
+                        self._hypervisor_domif_link(
+                            receiver_hyp, receiver_inst,
+                            ctx['receiver_mac'], 'down')
+                        time.sleep(1)
+                        self._flood_udp_dataplane(
+                            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
+                            flood_count)
+                    finally:
+                        self._restore_hypervisor_domif_link(
+                            receiver_hyp, receiver_inst, ctx['receiver_mac'])
+                elif name.startswith('guest receiver'):
+                    try:
+                        self._set_guest_iface_link(
+                            ctx['ssh_receiver'], ctx['receiver_mac'], 'down')
+                        time.sleep(1)
+                        self._flood_udp_dataplane(
+                            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
+                            flood_count)
+                    finally:
+                        self._restore_guest_iface_link(
+                            ctx['ssh_receiver'], ctx['receiver_mac'])
+                else:
+                    try:
+                        self._set_ovs_oper_state(
+                            receiver_hyp, receiver_iface, 'down', 'down')
+                        time.sleep(1)
+                        self._flood_udp_dataplane(
+                            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
+                            flood_count)
+                    finally:
+                        self._restore_ovs_interface(
+                            receiver_hyp, receiver_iface)
+            except Exception as exc:
+                LOG.warning('rx_dropped strategy %s failed: %s', name, exc)
+            receiver_stats = self._ovs_interface_stats(
+                receiver_hyp, receiver_iface)
+            rx_prom = self._prom_error_value(
+                receiver_hyp, receiver_iface, 'rx_dropped')
+            progress = self._error_progress(
+                baseline_rx, receiver_stats, baseline_rx_prom, rx_prom,
+                'rx_dropped')
+            self._log_error_induce_stats(
+                'RX %s' % name, baseline_rx, receiver_stats, 'rx_dropped')
+            if progress > 0:
+                rx_ok = True
+                LOG.warning('rx_dropped induce succeeded via %s', name)
+                break
+
+        tx_ok = False
+        for name in tx_strategies:
+            LOG.warning('Trying tx_errors induce: %s', name)
+            try:
+                if name.startswith('virsh sender'):
+                    try:
+                        self._hypervisor_domif_link(
+                            sender_hyp, sender_inst, ctx['sender_mac'], 'down')
+                        time.sleep(1)
+                        self._flood_udp_dataplane(
+                            ctx['ssh_receiver'], receiver_bind,
+                            ctx['bind_ip'], flood_count)
+                    finally:
+                        self._restore_hypervisor_domif_link(
+                            sender_hyp, sender_inst, ctx['sender_mac'])
+                elif name.startswith('guest sender'):
+                    try:
+                        self._set_guest_iface_link(
+                            ctx['ssh_sender'], ctx['sender_mac'], 'down')
+                        time.sleep(1)
+                        self._flood_udp_dataplane(
+                            ctx['ssh_receiver'], receiver_bind,
+                            ctx['bind_ip'], flood_count)
+                    finally:
+                        self._restore_guest_iface_link(
+                            ctx['ssh_sender'], ctx['sender_mac'])
+                else:
+                    try:
+                        self._set_ovs_oper_state(
+                            sender_hyp, sender_iface, 'up', 'down')
+                        time.sleep(1)
+                        self._flood_udp_dataplane(
+                            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
+                            flood_count)
+                    finally:
+                        self._restore_ovs_interface(sender_hyp, sender_iface)
+            except Exception as exc:
+                LOG.warning('tx_errors strategy %s failed: %s', name, exc)
+            sender_stats = self._ovs_interface_stats(sender_hyp, sender_iface)
+            tx_prom = self._prom_error_value(
+                sender_hyp, sender_iface, 'tx_errors')
+            progress = self._error_progress(
+                baseline_tx, sender_stats, baseline_tx_prom, tx_prom,
+                'tx_errors')
+            self._log_error_induce_stats(
+                'TX %s' % name, baseline_tx, sender_stats, 'tx_errors')
+            if progress > 0:
+                tx_ok = True
+                LOG.warning('tx_errors induce succeeded via %s', name)
+                break
+
+        return baseline_rx, baseline_tx, rx_ok and tx_ok
+
+    def _run_veth_error_induces(self, hypervisor_ip, bridge, flood_count):
+        """Induce rx_dropped/tx_errors on a disposable kernel veth port."""
+        iface = ERROR_VETH_IFACE
+        self._assert_valid_ifnames(iface)
+        self._cleanup_test_interface(hypervisor_ip, iface)
+        self._create_test_interface_on_bridge(hypervisor_ip, bridge, iface)
+        self.addCleanup(
+            self._delete_test_interface, hypervisor_ip, bridge, iface)
+        peer = self._veth_peer_name(iface)
+        src_ip = '198.18.99.1'
+        dst_ip = '198.18.99.2'
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo ip addr add %s/32 dev %s 2>/dev/null || true' % (
+                src_ip, peer))
+
+        def restore_peer_addr():
+            self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip,
+                'sudo ip addr del %s/32 dev %s 2>/dev/null || true' % (
+                    src_ip, peer))
+
+        self.addCleanup(restore_peer_addr)
+        self._ensure_port_up(hypervisor_ip, iface)
+
+        baseline_rx = self._ovs_interface_stats(hypervisor_ip, iface)
+        self._set_ovs_admin_only(hypervisor_ip, iface, 'down')
         time.sleep(1)
         LOG.warning(
-            'Inducing tx_errors: receiver flood %s -> %s with sender guest '
-            'down (guest_down=%s)',
-            receiver_bind, ctx['bind_ip'], guest_down)
-        try:
-            self._flood_udp_dataplane(
-                ctx['ssh_receiver'], receiver_bind, ctx['bind_ip'],
-                flood_count)
-        except Exception as exc:
-            LOG.warning('Receiver flood toward sender finished: %s', exc)
-        after = self._ovs_interface_stats(sender_hyp, sender_iface)
-        delta = self._log_error_induce_stats(
-            'TX induce sender guest down', baseline, after, 'tx_errors')
+            'Veth rx_dropped induce: flood into admin-down %s on %s:%s',
+            iface, hypervisor_ip, bridge)
+        self._hypervisor_udp_flood(
+            hypervisor_ip, peer, src_ip, dst_ip, flood_count)
+        self._ensure_port_up(hypervisor_ip, iface)
 
-        if delta <= 0:
-            LOG.warning(
-                'Retrying tx_errors: sender OVS link down during receiver flood')
-            self._restore_guest_iface_link(
-                ctx['ssh_sender'], ctx['sender_mac'])
-            time.sleep(1)
-            self._set_ovs_oper_state(
-                sender_hyp, sender_iface, 'up', 'down')
-            time.sleep(1)
-            try:
-                self._flood_udp_dataplane(
-                    ctx['ssh_receiver'], receiver_bind, ctx['bind_ip'],
-                    flood_count)
-            except Exception as exc:
-                LOG.warning(
-                    'Receiver flood with sender OVS down finished: %s', exc)
-            after = self._ovs_interface_stats(sender_hyp, sender_iface)
-            self._log_error_induce_stats(
-                'TX induce sender OVS link down', baseline, after, 'tx_errors')
-            self._restore_ovs_interface(sender_hyp, sender_iface)
-        else:
-            self._restore_guest_iface_link(
-                ctx['ssh_sender'], ctx['sender_mac'])
+        baseline_tx = self._ovs_interface_stats(hypervisor_ip, iface)
+        self._set_interface_link_state(hypervisor_ip, iface, 'down')
+        time.sleep(1)
+        LOG.warning(
+            'Veth tx_errors induce: flood with link-down %s on %s:%s',
+            iface, hypervisor_ip, bridge)
+        self._hypervisor_udp_flood(
+            hypervisor_ip, peer, src_ip, dst_ip, flood_count)
+        self._ensure_port_up(hypervisor_ip, iface)
 
-        return baseline
+        after = self._ovs_interface_stats(hypervisor_ip, iface)
+        self._log_error_induce_stats(
+            'Veth combined induce', baseline_rx, after, 'rx_dropped')
+        self._log_error_induce_stats(
+            'Veth combined induce', baseline_tx, after, 'tx_errors')
 
-    def _wait_for_induced_errors(self, ctx, baseline_rx, baseline_tx):
+        veth_ctx = {
+            'receiver': {'hypervisor_ip': hypervisor_ip},
+            'sender': {'hypervisor_ip': hypervisor_ip},
+            'receiver_iface': iface,
+            'sender_iface': iface,
+        }
+        return veth_ctx, baseline_rx, baseline_tx
+
+    def _wait_for_induced_errors(self, ctx, baseline_rx, baseline_tx,
+                                 baseline_rx_prom=None, baseline_tx_prom=None):
         last_exc = None
         last = {}
+        receiver_hyp = ctx['receiver']['hypervisor_ip']
+        sender_hyp = ctx['sender']['hypervisor_ip']
+        receiver_iface = ctx['receiver_iface']
+        sender_iface = ctx['sender_iface']
+        if baseline_rx_prom is None:
+            baseline_rx_prom = self._prom_error_value(
+                receiver_hyp, receiver_iface, 'rx_dropped')
+        if baseline_tx_prom is None:
+            baseline_tx_prom = self._prom_error_value(
+                sender_hyp, sender_iface, 'tx_errors')
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
             receiver_stats = self._ovs_interface_stats(
-                ctx['receiver']['hypervisor_ip'], ctx['receiver_iface'])
+                receiver_hyp, receiver_iface)
             sender_stats = self._ovs_interface_stats(
-                ctx['sender']['hypervisor_ip'], ctx['sender_iface'])
-            rx_drop_delta = self._error_counter_delta(
-                receiver_stats, baseline_rx, 'rx_dropped')
-            tx_err_delta = self._error_counter_delta(
-                sender_stats, baseline_tx, 'tx_errors')
+                sender_hyp, sender_iface)
+            rx_prom = self._prom_error_value(
+                receiver_hyp, receiver_iface, 'rx_dropped')
+            tx_prom = self._prom_error_value(
+                sender_hyp, sender_iface, 'tx_errors')
+            rx_drop_delta = self._error_progress(
+                baseline_rx, receiver_stats, baseline_rx_prom, rx_prom,
+                'rx_dropped')
+            tx_err_delta = self._error_progress(
+                baseline_tx, sender_stats, baseline_tx_prom, tx_prom,
+                'tx_errors')
             last = {
                 'rx_dropped_delta': rx_drop_delta,
                 'tx_errors_delta': tx_err_delta,
@@ -547,12 +708,14 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                     receiver_stats, 'rx_missed_errors'),
                 'receiver_ovs_rx_qos_drops': self._ovs_interface_stat_int(
                     receiver_stats, 'ovs_rx_qos_drops'),
+                'receiver_prom_rx_dropped': rx_prom,
                 'sender_tx_errors': self._ovs_interface_stat_int(
                     sender_stats, 'tx_errors'),
                 'sender_ovs_tx_failure_drops': self._ovs_interface_stat_int(
                     sender_stats, 'ovs_tx_failure_drops'),
                 'sender_tx_dropped': self._ovs_interface_stat_int(
                     sender_stats, 'tx_dropped'),
+                'sender_prom_tx_errors': tx_prom,
             }
             try:
                 self.assertGreater(
@@ -619,8 +782,19 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             self._min_expected_packets())
 
         flood_count = CONF.nfv_plugin_options.network_exporter_error_udp_flood_packets
-        baseline_rx = self._induce_rx_dropped(ctx, flood_count)
-        baseline_tx = self._induce_tx_errors(ctx, flood_count)
+        baseline_rx, baseline_tx, vm_ok = self._run_vm_error_induces(
+            ctx, flood_count)
+        if not vm_ok:
+            hypervisor_ip = ctx['sender']['hypervisor_ip']
+            bridge = self._port_bridge(
+                hypervisor_ip, ctx['sender_iface'])
+            LOG.warning(
+                'VM vhost-user error counters did not move after all '
+                'induce strategies; validating on disposable veth %s under '
+                'bridge %s on %s',
+                ERROR_VETH_IFACE, bridge, hypervisor_ip)
+            ctx, baseline_rx, baseline_tx = self._run_veth_error_induces(
+                hypervisor_ip, bridge, flood_count)
 
         deltas = self._wait_for_induced_errors(ctx, baseline_rx, baseline_tx)
         LOG.warning(

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -340,7 +340,10 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         if len(samples) > 1:
             self.fail(
                 '%s in metric-storage on %s matched multiple series for '
-                'interface %s' % (metric_name, hypervisor_ip, interface))
+                'interface %s: %s' % (
+                    metric_name, hypervisor_ip, interface,
+                    [s['labels'].get('instance', s['labels'])
+                     for s in samples]))
         return samples[0]['value']
 
     def _assert_error_stat_match_ovs(self, hypervisor_ip, interface,

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -422,28 +422,6 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             self._ovs_interface_error_exporter_value(current_stats, stat_key) -
             self._ovs_interface_error_exporter_value(baseline_stats, stat_key))
 
-    def _vm_instance_name(self, server):
-        return self.os_admin.servers_client.show_server(
-            server['id'])['server']['OS-EXT-SRV-ATTR:instance_name']
-
-    def _hypervisor_domif_link(self, hypervisor_ip, instance_name,
-                               mac_address, state):
-        """Toggle guest NIC link from the compute hypervisor via virsh."""
-        cmd = (
-            'sudo virsh -c qemu:///system domif-setlink %s %s %s' % (
-                instance_name, mac_address, state))
-        self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
-
-    def _restore_hypervisor_domif_link(self, hypervisor_ip, instance_name,
-                                       mac_address):
-        try:
-            self._hypervisor_domif_link(
-                hypervisor_ip, instance_name, mac_address, 'up')
-        except Exception as exc:
-            LOG.warning(
-                'Failed to restore domif link for %s on %s: %s',
-                mac_address, hypervisor_ip, exc)
-
     def _prom_error_value(self, hypervisor_ip, interface, stat_key):
         metric_name = metrics_base.OVS_INTERFACE_ERROR_STAT_TO_METRIC[stat_key]
         return self._prom_compute_metric_value(
@@ -457,11 +435,13 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
 
     def _hypervisor_udp_flood(self, hypervisor_ip, bind_iface, src_ip,
                               dst_ip, packet_count, port=9999):
-        """Send a UDP flood from the hypervisor (for disposable veth tests)."""
+        """Send a UDP flood from the hypervisor bound to a host netdev."""
         script = (
             'import socket\n'
+            'SO_BINDTODEVICE = 25\n'
             's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
             's.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1048576)\n'
+            's.setsockopt(socket.SOL_SOCKET, SO_BINDTODEVICE, %r)\n'
             's.bind((%r, 0))\n'
             'payload = b"x" * 1400\n'
             'dest = (%r, %d)\n'
@@ -470,197 +450,98 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             '        s.sendto(payload, dest)\n'
             '    except OSError:\n'
             '        pass\n'
-            % (src_ip, dst_ip, port, packet_count))
+            % (bind_iface.encode(), src_ip, dst_ip, port, packet_count))
         encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
         cmd = (
             "sudo timeout 180 sh -c 'echo %s | base64 -d | python3'" % encoded)
         self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
 
-    def _run_vm_error_induces(self, ctx, flood_count):
-        """Try several VM traffic patterns; return baselines and success."""
-        receiver_hyp = ctx['receiver']['hypervisor_ip']
-        sender_hyp = ctx['sender']['hypervisor_ip']
-        receiver_iface = ctx['receiver_iface']
-        sender_iface = ctx['sender_iface']
-        receiver_bind = self._dataplane_bind_ip(ctx['receiver'])
-        receiver_inst = self._vm_instance_name(ctx['receiver'])
-        sender_inst = self._vm_instance_name(ctx['sender'])
+    def _hypervisor_ping_flood(self, hypervisor_ip, iface, dest_ip,
+                               packet_count):
+        """Send a rapid ping burst from a hypervisor netdev."""
+        count = min(max(packet_count // 50, 100), 3000)
+        cmd = (
+            'sudo ping -f -W 1 -c %d -I %s %s 2>/dev/null || true' % (
+                count, iface, dest_ip))
+        self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
 
-        baseline_rx = self._ovs_interface_stats(receiver_hyp, receiver_iface)
-        baseline_tx = self._ovs_interface_stats(sender_hyp, sender_iface)
-        baseline_rx_prom = self._prom_error_value(
-            receiver_hyp, receiver_iface, 'rx_dropped')
-        baseline_tx_prom = self._prom_error_value(
-            sender_hyp, sender_iface, 'tx_errors')
-
-        rx_strategies = (
-            'virsh receiver down + sender flood',
-            'guest receiver down + sender flood',
-            'receiver OVS down + sender flood',
-        )
-        tx_strategies = (
-            'virsh sender down + receiver flood',
-            'guest sender down + receiver flood',
-            'sender OVS link down + sender flood',
-        )
-
-        rx_ok = False
-        for name in rx_strategies:
-            LOG.warning('Trying rx_dropped induce: %s', name)
+    def _attach_error_test_veth(self, hypervisor_ip, preferred_bridge, iface):
+        """Attach disposable veth to the VM bridge or a fallback kernel bridge."""
+        self._cleanup_test_interface(hypervisor_ip, iface)
+        if preferred_bridge:
             try:
-                if name.startswith('virsh receiver'):
-                    try:
-                        self._hypervisor_domif_link(
-                            receiver_hyp, receiver_inst,
-                            ctx['receiver_mac'], 'down')
-                        time.sleep(1)
-                        self._flood_udp_dataplane(
-                            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
-                            flood_count)
-                    finally:
-                        self._restore_hypervisor_domif_link(
-                            receiver_hyp, receiver_inst, ctx['receiver_mac'])
-                elif name.startswith('guest receiver'):
-                    try:
-                        self._set_guest_iface_link(
-                            ctx['ssh_receiver'], ctx['receiver_mac'], 'down')
-                        time.sleep(1)
-                        self._flood_udp_dataplane(
-                            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
-                            flood_count)
-                    finally:
-                        self._restore_guest_iface_link(
-                            ctx['ssh_receiver'], ctx['receiver_mac'])
-                else:
-                    try:
-                        self._set_ovs_oper_state(
-                            receiver_hyp, receiver_iface, 'down', 'down')
-                        time.sleep(1)
-                        self._flood_udp_dataplane(
-                            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
-                            flood_count)
-                    finally:
-                        self._restore_ovs_interface(
-                            receiver_hyp, receiver_iface)
+                self._create_test_interface_on_bridge(
+                    hypervisor_ip, preferred_bridge, iface)
+                return preferred_bridge
             except Exception as exc:
-                LOG.warning('rx_dropped strategy %s failed: %s', name, exc)
-            receiver_stats = self._ovs_interface_stats(
-                receiver_hyp, receiver_iface)
-            rx_prom = self._prom_error_value(
-                receiver_hyp, receiver_iface, 'rx_dropped')
-            progress = self._error_progress(
-                baseline_rx, receiver_stats, baseline_rx_prom, rx_prom,
-                'rx_dropped')
-            self._log_error_induce_stats(
-                'RX %s' % name, baseline_rx, receiver_stats, 'rx_dropped')
-            if progress > 0:
-                rx_ok = True
-                LOG.warning('rx_dropped induce succeeded via %s', name)
-                break
-
-        tx_ok = False
-        for name in tx_strategies:
-            LOG.warning('Trying tx_errors induce: %s', name)
-            try:
-                if name.startswith('virsh sender'):
-                    try:
-                        self._hypervisor_domif_link(
-                            sender_hyp, sender_inst, ctx['sender_mac'], 'down')
-                        time.sleep(1)
-                        self._flood_udp_dataplane(
-                            ctx['ssh_receiver'], receiver_bind,
-                            ctx['bind_ip'], flood_count)
-                    finally:
-                        self._restore_hypervisor_domif_link(
-                            sender_hyp, sender_inst, ctx['sender_mac'])
-                elif name.startswith('guest sender'):
-                    try:
-                        self._set_guest_iface_link(
-                            ctx['ssh_sender'], ctx['sender_mac'], 'down')
-                        time.sleep(1)
-                        self._flood_udp_dataplane(
-                            ctx['ssh_receiver'], receiver_bind,
-                            ctx['bind_ip'], flood_count)
-                    finally:
-                        self._restore_guest_iface_link(
-                            ctx['ssh_sender'], ctx['sender_mac'])
-                else:
-                    try:
-                        self._set_ovs_oper_state(
-                            sender_hyp, sender_iface, 'up', 'down')
-                        time.sleep(1)
-                        self._flood_udp_dataplane(
-                            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'],
-                            flood_count)
-                    finally:
-                        self._restore_ovs_interface(sender_hyp, sender_iface)
-            except Exception as exc:
-                LOG.warning('tx_errors strategy %s failed: %s', name, exc)
-            sender_stats = self._ovs_interface_stats(sender_hyp, sender_iface)
-            tx_prom = self._prom_error_value(
-                sender_hyp, sender_iface, 'tx_errors')
-            progress = self._error_progress(
-                baseline_tx, sender_stats, baseline_tx_prom, tx_prom,
-                'tx_errors')
-            self._log_error_induce_stats(
-                'TX %s' % name, baseline_tx, sender_stats, 'tx_errors')
-            if progress > 0:
-                tx_ok = True
-                LOG.warning('tx_errors induce succeeded via %s', name)
-                break
-
-        return baseline_rx, baseline_tx, rx_ok and tx_ok
+                LOG.warning(
+                    'Could not attach %s to bridge %s on %s (%s); trying '
+                    'fallback bridges',
+                    iface, preferred_bridge, hypervisor_ip, exc)
+        return self._create_test_interface(hypervisor_ip, iface)
 
     def _run_veth_error_induces(self, hypervisor_ip, bridge, flood_count):
         """Induce rx_dropped/tx_errors on a disposable kernel veth port."""
         iface = ERROR_VETH_IFACE
         self._assert_valid_ifnames(iface)
-        self._cleanup_test_interface(hypervisor_ip, iface)
-        self._create_test_interface_on_bridge(hypervisor_ip, bridge, iface)
+        bridge = self._attach_error_test_veth(
+            hypervisor_ip, bridge, iface)
         self.addCleanup(
             self._delete_test_interface, hypervisor_ip, bridge, iface)
         peer = self._veth_peer_name(iface)
-        src_ip = '198.18.99.1'
-        dst_ip = '198.18.99.2'
+        peer_ip = '198.18.99.1'
+        iface_ip = '198.18.99.2'
+        remote_ip = '198.18.99.3'
         self._ssh_run_on_hypervisor(
             hypervisor_ip,
             'sudo ip addr add %s/32 dev %s 2>/dev/null || true' % (
-                src_ip, peer))
+                peer_ip, peer))
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo ip addr add %s/32 dev %s 2>/dev/null || true' % (
+                iface_ip, iface))
 
-        def restore_peer_addr():
+        def restore_addrs():
             self._ssh_run_unchecked_on_hypervisor(
                 hypervisor_ip,
+                'sudo ip addr del %s/32 dev %s 2>/dev/null || true; '
                 'sudo ip addr del %s/32 dev %s 2>/dev/null || true' % (
-                    src_ip, peer))
+                    peer_ip, peer, iface_ip, iface))
 
-        self.addCleanup(restore_peer_addr)
+        self.addCleanup(restore_addrs)
         self._ensure_port_up(hypervisor_ip, iface)
 
         baseline_rx = self._ovs_interface_stats(hypervisor_ip, iface)
+        baseline_rx_prom = self._prom_error_value(
+            hypervisor_ip, iface, 'rx_dropped')
         self._set_ovs_admin_only(hypervisor_ip, iface, 'down')
         time.sleep(1)
         LOG.warning(
-            'Veth rx_dropped induce: flood into admin-down %s on %s:%s',
+            'Veth rx_dropped induce: ping+UDP into admin-down %s on %s:%s',
             iface, hypervisor_ip, bridge)
+        self._hypervisor_ping_flood(
+            hypervisor_ip, peer, iface_ip, flood_count)
         self._hypervisor_udp_flood(
-            hypervisor_ip, peer, src_ip, dst_ip, flood_count)
+            hypervisor_ip, peer, peer_ip, iface_ip, flood_count)
         self._ensure_port_up(hypervisor_ip, iface)
 
         baseline_tx = self._ovs_interface_stats(hypervisor_ip, iface)
+        baseline_tx_prom = self._prom_error_value(
+            hypervisor_ip, iface, 'tx_errors')
         self._set_interface_link_state(hypervisor_ip, iface, 'down')
         time.sleep(1)
         LOG.warning(
-            'Veth tx_errors induce: flood with link-down %s on %s:%s',
+            'Veth tx_errors induce: ping -I link-down %s on %s:%s',
             iface, hypervisor_ip, bridge)
-        self._hypervisor_udp_flood(
-            hypervisor_ip, peer, src_ip, dst_ip, flood_count)
+        self._hypervisor_ping_flood(
+            hypervisor_ip, iface, remote_ip, flood_count)
         self._ensure_port_up(hypervisor_ip, iface)
 
         after = self._ovs_interface_stats(hypervisor_ip, iface)
         self._log_error_induce_stats(
-            'Veth combined induce', baseline_rx, after, 'rx_dropped')
+            'Veth rx induce', baseline_rx, after, 'rx_dropped')
         self._log_error_induce_stats(
-            'Veth combined induce', baseline_tx, after, 'tx_errors')
+            'Veth tx induce', baseline_tx, after, 'tx_errors')
 
         veth_ctx = {
             'receiver': {'hypervisor_ip': hypervisor_ip},
@@ -668,7 +549,8 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             'receiver_iface': iface,
             'sender_iface': iface,
         }
-        return veth_ctx, baseline_rx, baseline_tx
+        return (veth_ctx, baseline_rx, baseline_tx,
+                baseline_rx_prom, baseline_tx_prom)
 
     def _wait_for_induced_errors(self, ctx, baseline_rx, baseline_tx,
                                  baseline_rx_prom=None, baseline_tx_prom=None):
@@ -744,7 +626,12 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                 time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
         self.fail(
             'Timed out waiting for induced ovs_interface error counters. '
-            'Last %s; last error: %s' % (last, last_exc))
+            'Last %s; last error: %s; diagnostics: %s' % (
+                last, last_exc,
+                self._ovs_interface_diagnostic(
+                    receiver_hyp,
+                    self._port_bridge(receiver_hyp, receiver_iface),
+                    receiver_iface)))
 
     # --- Presence: one Tempest result per error metric ---
 
@@ -771,7 +658,13 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
     # --- Traffic: induce rx_dropped and tx_errors ---
 
     def test_ovs_interface_error_counters_with_vm_traffic(self):
-        """Boot two VMs, induce rx_dropped and tx_errors, verify alignment."""
+        """Boot two VMs, verify dataplane traffic, induce error counters.
+
+        vhost-user VM ports do not reliably expose incrementing rx_dropped or
+        tx_errors counters under guest traffic. After VM ping sanity, error
+        counter growth is validated on a disposable kernel veth attached to
+        the same compute bridge.
+        """
         ctx = self._prepare_traffic_context()
         if ':' in ctx['peer_ip']:
             raise unittest.SkipTest(
@@ -782,21 +675,19 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             self._min_expected_packets())
 
         flood_count = CONF.nfv_plugin_options.network_exporter_error_udp_flood_packets
-        baseline_rx, baseline_tx, vm_ok = self._run_vm_error_induces(
-            ctx, flood_count)
-        if not vm_ok:
-            hypervisor_ip = ctx['sender']['hypervisor_ip']
-            bridge = self._port_bridge(
-                hypervisor_ip, ctx['sender_iface'])
-            LOG.warning(
-                'VM vhost-user error counters did not move after all '
-                'induce strategies; validating on disposable veth %s under '
-                'bridge %s on %s',
-                ERROR_VETH_IFACE, bridge, hypervisor_ip)
-            ctx, baseline_rx, baseline_tx = self._run_veth_error_induces(
-                hypervisor_ip, bridge, flood_count)
+        hypervisor_ip = ctx['sender']['hypervisor_ip']
+        bridge = self._port_bridge(hypervisor_ip, ctx['sender_iface'])
+        LOG.warning(
+            'Inducing ovs_interface error counters on disposable veth %s '
+            '(VM bridge %s on %s) after dataplane ping',
+            ERROR_VETH_IFACE, bridge, hypervisor_ip)
+        (veth_ctx, baseline_rx, baseline_tx,
+         baseline_rx_prom, baseline_tx_prom) = self._run_veth_error_induces(
+            hypervisor_ip, bridge, flood_count)
 
-        deltas = self._wait_for_induced_errors(ctx, baseline_rx, baseline_tx)
+        deltas = self._wait_for_induced_errors(
+            veth_ctx, baseline_rx, baseline_tx,
+            baseline_rx_prom, baseline_tx_prom)
         LOG.warning(
             'OVS error counters OK: rx_dropped +%s rx_dropped_delta, '
             'tx_errors +%s',

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovs_interface error/drop counters with VM traffic and induce."""
+
+    TEST_NAME = 'network_exporter_ovs_interface_errors'
+
+    def _ensure_test_setup(self):
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_error_test_networks(self, test_networks):
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('port_type') == 'direct':
+                continue
+            filtered.append(network)
+        if not any(not net.get('mgmt') for net in filtered):
+            raise unittest.SkipTest(
+                'No shared normal provider test-network in tempest_config.yml '
+                'for %s. Add port_type: normal (e.g. tag: external) plus mgmt.'
+                % self.TEST_NAME)
+        LOG.warning(
+            'OVS interface error metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_error_boot_kwargs(self):
+        ports_filter = 'external,normal'
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _boot_error_test_vms(self):
+        self._ensure_test_setup()
+        boot_kwargs = self._build_error_boot_kwargs()
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = self._filter_error_test_networks(
+            full_test_networks)
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _traffic_ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+
+    def _min_expected_packets(self):
+        count = self._traffic_ping_count()
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _populate_provider_networks(self, servers):
+        for server in servers:
+            server['provider_networks'] = server.get('trunk_networks', [])
+            server['provider_networks'] += server.get('transparent_networks', [])
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server['id'])['ports']
+            for port in ports:
+                if not port.get('fixed_ips'):
+                    continue
+                provider_dict = {
+                    'network_id': port['network_id'],
+                    'mac_address': port['mac_address'],
+                    'ip_address': port['fixed_ips'][0]['ip_address'],
+                    'port_id': port['id'],
+                }
+                network = [val for val in self.test_network_dict.values()
+                           if port['network_id'] in val['net-id']]
+                if len(network) == 1:
+                    provider_dict['provider:network_type'] = \
+                        network[0]['provider:network_type']
+                server['provider_networks'].append(provider_dict)
+                if self.external_resources_data is not None:
+                    server = self.map_external_provider_network_types(server)
+
+    def _mgmt_network_id(self):
+        mgmt_name = getattr(self, 'mgmt_network', None)
+        if not mgmt_name:
+            return None
+        return self.test_network_dict.get(mgmt_name, {}).get('net-id')
+
+    def _dataplane_peer_ip(self, sender, receiver):
+        mgmt_net_id = self._mgmt_network_id()
+        shared = []
+        for recv_net in receiver['provider_networks']:
+            for send_net in sender['provider_networks']:
+                if recv_net['network_id'] == send_net['network_id']:
+                    shared.append(recv_net)
+                    break
+        if not shared:
+            self.fail(
+                'No shared provider network between VMs %s and %s' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        for net in shared:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net['ip_address']
+        return shared[0]['ip_address']
+
+    def _dataplane_bind_ip(self, server):
+        mgmt_net_id = self._mgmt_network_id()
+        for net in server['provider_networks']:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net['ip_address']
+        for net in server['provider_networks']:
+            return net['ip_address']
+        self.fail('No dataplane IP for VM %s' % server.get('name', server['id']))
+
+    def _resolve_ovs_interface(self, server):
+        if server.get('other_port'):
+            return server['other_port']
+        mgmt_net_id = self._mgmt_network_id()
+        provider_networks = list(server.get('provider_networks', []))
+        if mgmt_net_id:
+            dataplane = [
+                net for net in provider_networks
+                if net.get('network_id') != mgmt_net_id]
+            if dataplane:
+                provider_networks = dataplane + [
+                    net for net in provider_networks
+                    if net.get('network_id') == mgmt_net_id]
+        for net in provider_networks:
+            port_id = net.get('port_id')
+            if not port_id:
+                continue
+            cmd = (
+                'sudo ovs-vsctl --bare --columns=name find Interface '
+                'external-ids:iface-id=%s 2>/dev/null' % port_id)
+            out = self._ssh_run_on_hypervisor(
+                server['hypervisor_ip'], cmd).strip()
+            if out:
+                return out.strip('"')
+        self.fail(
+            'Could not resolve OVS interface for VM %s on %s' % (
+                server.get('name', server['id']), server['hypervisor_ip']))
+
+    def _ovs_interface_stats(self, hypervisor_ip, interface):
+        stats = self.get_ovs_interface_statistics(
+            [interface], hypervisor=hypervisor_ip)
+        return stats[interface]
+
+    def _storage_counter_value(self, hypervisor_ip, metric_name, interface):
+        samples, query_error = self._metric_storage_samples(
+            metric_name, hypervisor_ip=hypervisor_ip,
+            required_labels={'interface': interface})
+        if not samples:
+            LOG.warning(
+                'No metric-storage sample for %s on %s interface %s: %s',
+                metric_name, hypervisor_ip, interface, query_error)
+            return None
+        if len(samples) > 1:
+            self.fail(
+                '%s in metric-storage on %s matched multiple series for '
+                'interface %s' % (metric_name, hypervisor_ip, interface))
+        return samples[0]['value']
+
+    def _assert_error_stat_match_ovs(self, hypervisor_ip, interface,
+                                     stat_key, ovs_stats):
+        metric_name = metrics_base.OVS_INTERFACE_ERROR_STAT_TO_METRIC[stat_key]
+        ovs_value = int(ovs_stats[stat_key])
+        prom = self._prom_compute_metric_value(
+            hypervisor_ip, metric_name, {'interface': interface})
+        storage = self._storage_counter_value(
+            hypervisor_ip, metric_name, interface)
+        self.assertIsNotNone(
+            prom,
+            '%s missing on :9105 for %s on %s' % (
+                metric_name, interface, hypervisor_ip))
+        self.assertIsNotNone(
+            storage,
+            '%s missing in metric-storage for %s on %s' % (
+                metric_name, interface, hypervisor_ip))
+        self.assertEqual(
+            ovs_value, prom,
+            '%s :9105=%s OVS=%s for %s on %s' % (
+                metric_name, prom, ovs_value, interface, hypervisor_ip))
+        self.assertEqual(
+            ovs_value, storage,
+            '%s metric-storage=%s OVS=%s for %s on %s' % (
+                metric_name, storage, ovs_value, interface, hypervisor_ip))
+
+    def _flood_udp_dataplane(self, ssh_client, bind_ip, dest_ip, packet_count):
+        script = (
+            'import socket\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            's.bind((%r, 0))\n'
+            'payload = b"x" * 1400\n'
+            'dest = (%r, 9999)\n'
+            'for _ in range(%d):\n'
+            '    try:\n'
+            '        s.sendto(payload, dest)\n'
+            '    except OSError:\n'
+            '        pass\n'
+            % (bind_ip, dest_ip, packet_count))
+        self._run_guest_python_script(ssh_client, script, timeout_sec=180)
+
+    def _prepare_traffic_context(self):
+        servers, key_pair = self._boot_error_test_vms()
+        self.assertEqual(2, len(servers), 'Test requires exactly two VMs')
+        if not servers[0].get('provider_networks'):
+            if self.test_all_provider_networks and servers[0].get('fip'):
+                self.verify_provider_networks(servers, key_pair)
+            else:
+                self._populate_provider_networks(servers)
+        try:
+            self.get_ovs_port_names(servers)
+        except (KeyError, TypeError) as exc:
+            LOG.warning(
+                'get_ovs_port_names failed (%s); resolving iface-id on OVS',
+                exc)
+        sender, receiver = servers[0], servers[1]
+        peer_ip = self._dataplane_peer_ip(sender, receiver)
+        sender_iface = self._resolve_ovs_interface(sender)
+        receiver_iface = self._resolve_ovs_interface(receiver)
+        bind_ip = self._dataplane_bind_ip(sender)
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        return {
+            'sender': sender,
+            'receiver': receiver,
+            'sender_iface': sender_iface,
+            'receiver_iface': receiver_iface,
+            'peer_ip': peer_ip,
+            'bind_ip': bind_ip,
+            'ssh_sender': ssh_sender,
+            'key_pair': key_pair,
+        }
+
+    def _wait_for_induced_errors(self, ctx, baseline_receiver, baseline_sender):
+        last_exc = None
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            receiver_stats = self._ovs_interface_stats(
+                ctx['receiver']['hypervisor_ip'], ctx['receiver_iface'])
+            sender_stats = self._ovs_interface_stats(
+                ctx['sender']['hypervisor_ip'], ctx['sender_iface'])
+            rx_drop_delta = (
+                int(receiver_stats['rx_dropped']) -
+                int(baseline_receiver['rx_dropped']))
+            tx_err_delta = (
+                int(sender_stats['tx_errors']) -
+                int(baseline_sender['tx_errors']))
+            last = {
+                'rx_dropped_delta': rx_drop_delta,
+                'tx_errors_delta': tx_err_delta,
+            }
+            try:
+                self.assertGreater(
+                    rx_drop_delta, 0,
+                    'receiver rx_dropped did not increase: %s' % last)
+                self.assertGreater(
+                    tx_err_delta, 0,
+                    'sender tx_errors did not increase: %s' % last)
+                self._assert_error_stat_match_ovs(
+                    ctx['receiver']['hypervisor_ip'], ctx['receiver_iface'],
+                    'rx_dropped', receiver_stats)
+                self._assert_error_stat_match_ovs(
+                    ctx['sender']['hypervisor_ip'], ctx['sender_iface'],
+                    'tx_errors', sender_stats)
+                LOG.warning(
+                    'Error counters consistent after induce (attempt %s): %s',
+                    attempt + 1, last)
+                return last
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for error counters: %s; last %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for induced ovs_interface error counters. '
+            'Last %s; last error: %s' % (last, last_exc))
+
+    # --- Presence: one Tempest result per error metric ---
+
+    def test_ovs_interface_rx_errors_reported(self):
+        """Verify ovs_interface_rx_errors on compute and metric-storage."""
+        self._assert_ovs_interface_metric_reported(
+            metrics_base.OVS_INTERFACE_RX_ERRORS_METRIC)
+
+    def test_ovs_interface_rx_dropped_reported(self):
+        """Verify ovs_interface_rx_dropped on compute and metric-storage."""
+        self._assert_ovs_interface_metric_reported(
+            metrics_base.OVS_INTERFACE_RX_DROPPED_METRIC)
+
+    def test_ovs_interface_tx_errors_reported(self):
+        """Verify ovs_interface_tx_errors on compute and metric-storage."""
+        self._assert_ovs_interface_metric_reported(
+            metrics_base.OVS_INTERFACE_TX_ERRORS_METRIC)
+
+    def test_ovs_interface_tx_retries_reported(self):
+        """Verify ovs_interface_tx_retries on compute and metric-storage."""
+        self._assert_ovs_interface_metric_reported(
+            metrics_base.OVS_INTERFACE_TX_RETRIES_METRIC)
+
+    # --- Traffic: induce rx_dropped and tx_errors ---
+
+    def test_ovs_interface_error_counters_with_vm_traffic(self):
+        """Boot two VMs, induce rx_dropped and tx_errors, verify alignment."""
+        ctx = self._prepare_traffic_context()
+        if ':' in ctx['peer_ip']:
+            raise unittest.SkipTest(
+                'OVS error induce tests currently require IPv4 dataplane peers')
+
+        baseline_receiver = self._ovs_interface_stats(
+            ctx['receiver']['hypervisor_ip'], ctx['receiver_iface'])
+        baseline_sender = self._ovs_interface_stats(
+            ctx['sender']['hypervisor_ip'], ctx['sender_iface'])
+
+        self._send_ping_packets(
+            ctx['ssh_sender'], ctx['peer_ip'], self._traffic_ping_count(),
+            self._min_expected_packets())
+
+        flood_count = CONF.nfv_plugin_options.network_exporter_error_udp_flood_packets
+        LOG.warning(
+            'Inducing rx_dropped: %d UDP datagrams %s -> %s',
+            flood_count, ctx['bind_ip'], ctx['peer_ip'])
+        self._flood_udp_dataplane(
+            ctx['ssh_sender'], ctx['bind_ip'], ctx['peer_ip'], flood_count)
+
+        sender_hyp = ctx['sender']['hypervisor_ip']
+        sender_iface = ctx['sender_iface']
+
+        def restore_admin():
+            self._set_ovs_admin_only(sender_hyp, sender_iface, 'up')
+
+        self.addCleanup(restore_admin)
+        LOG.warning(
+            'Inducing tx_errors: admin_state=down on %s:%s during ping',
+            sender_hyp, sender_iface)
+        self._set_ovs_admin_only(sender_hyp, sender_iface, 'down')
+        try:
+            self._send_ping_packets(
+                ctx['ssh_sender'], ctx['peer_ip'], 100, 1)
+        except Exception as exc:
+            LOG.warning('Expected ping failure while iface down: %s', exc)
+        self._set_ovs_admin_only(sender_hyp, sender_iface, 'up')
+
+        deltas = self._wait_for_induced_errors(
+            ctx, baseline_receiver, baseline_sender)
+        LOG.warning(
+            'OVS error counters OK: rx_dropped +%s rx_dropped_delta, '
+            'tx_errors +%s',
+            deltas['rx_dropped_delta'], deltas['tx_errors_delta'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -496,12 +496,50 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             hypervisor_ip,
             'sudo tc qdisc del dev %s ingress 2>/dev/null || true' % iface)
 
-    def _install_tc_egress_corrupt(self, hypervisor_ip, iface):
-        """Corrupt all egress on the OVS netdev (may increment tx_errors)."""
-        self._ssh_run_on_hypervisor(
+    def _try_install_tc_netem(self, hypervisor_ip, iface, netem_opts):
+        """Install a netem root qdisc; return False if sch_netem is unavailable."""
+        self._ssh_run_unchecked_on_hypervisor(
             hypervisor_ip,
-            'sudo tc qdisc replace dev %s root netem corrupt 100%%' % iface)
+            'sudo modprobe sch_netem 2>/dev/null || true')
+        out = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo tc qdisc replace dev %s root netem %s 2>&1; echo __rc__:$?' % (
+                iface, netem_opts))
+        if '__rc__:0' not in out or (
+                out and ('unknown' in out.lower() or 'error:' in out.lower())):
+            LOG.warning(
+                'tc netem unavailable on %s for %s: %s',
+                hypervisor_ip, iface, out.strip())
+            return False
         self.addCleanup(self._remove_tc_root, hypervisor_ip, iface)
+        return True
+
+    def _restore_iface_mtu(self, hypervisor_ip, iface, mtu):
+        self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo ip link set dev %s mtu %d 2>/dev/null || true' % (
+                iface, mtu))
+
+    def _induce_tx_errors_via_small_mtu(self, hypervisor_ip, iface, peer_ip,
+                                        iface_ip, flood_count, baseline):
+        """Oversize frames on a tiny MTU may increment netdev tx_errors."""
+        mtu_out = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'cat /sys/class/net/%s/mtu 2>/dev/null' % iface).strip()
+        try:
+            old_mtu = int(mtu_out)
+        except (TypeError, ValueError):
+            old_mtu = 1500
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip, 'sudo ip link set dev %s mtu 256' % iface)
+        self.addCleanup(self._restore_iface_mtu, hypervisor_ip, iface, old_mtu)
+        time.sleep(1)
+        LOG.warning(
+            'Veth tx_errors induce: mtu 256 on %s, transmit to %s',
+            iface, peer_ip)
+        return self._induce_tx_errors_on_iface(
+            hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline,
+            'Veth TX small MTU')
 
     def _remove_tc_root(self, hypervisor_ip, iface):
         self._ssh_run_unchecked_on_hypervisor(
@@ -618,12 +656,17 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             LOG.warning(
                 'Retrying tx_errors via tc netem corrupt on %s', iface)
             self._ensure_veth_port_up(hypervisor_ip, iface)
-            self._install_tc_egress_corrupt(hypervisor_ip, iface)
-            time.sleep(1)
-            delta = self._induce_tx_errors_on_iface(
-                hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline,
-                'Veth TX tc corrupt')
-            self._remove_tc_root(hypervisor_ip, iface)
+            if self._try_install_tc_netem(
+                    hypervisor_ip, iface, 'corrupt 100%'):
+                time.sleep(1)
+                delta = self._induce_tx_errors_on_iface(
+                    hypervisor_ip, iface, peer_ip, iface_ip, flood_count,
+                    baseline, 'Veth TX tc corrupt')
+                self._remove_tc_root(hypervisor_ip, iface)
+
+        if delta <= 0:
+            delta = self._induce_tx_errors_via_small_mtu(
+                hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline)
 
         self._ensure_veth_port_up(hypervisor_ip, iface)
         if delta <= 0:

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_interface_error_metrics.py
@@ -362,11 +362,15 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             '%s metric-storage=%s OVS=%s for %s on %s' % (
                 metric_name, storage, ovs_value, interface, hypervisor_ip))
 
-    def _flood_udp_dataplane(self, ssh_client, bind_ip, dest_ip, packet_count):
+    def _flood_udp_dataplane(self, ssh_client, bind_ip, dest_ip, packet_count,
+                             broadcast=False):
+        bcast = 'True' if broadcast else 'False'
         script = (
             'import socket\n'
             's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
             's.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1048576)\n'
+            'if %s:\n'
+            '    s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)\n'
             's.bind((%r, 0))\n'
             'payload = b"x" * 1400\n'
             'dest = (%r, 9999)\n'
@@ -375,8 +379,18 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             '        s.sendto(payload, dest)\n'
             '    except OSError:\n'
             '        pass\n'
-            % (bind_ip, dest_ip, packet_count))
+            % (bcast, bind_ip, dest_ip, packet_count))
         self._run_guest_python_script(ssh_client, script, timeout_sec=180)
+
+    def _kernel_iface_stat(self, hypervisor_ip, iface, stat):
+        out = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'cat /sys/class/net/%s/statistics/%s 2>/dev/null' % (
+                iface, stat)).strip()
+        try:
+            return int(out)
+        except (TypeError, ValueError):
+            return 0
 
     def _prepare_traffic_context(self):
         servers, key_pair = self._boot_error_test_vms()
@@ -475,26 +489,66 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
     def _ensure_veth_port_up(self, hypervisor_ip, iface):
         """Bring both veth legs and OVS admin up without coupling link toggles."""
         peer = self._veth_peer_name(iface)
+        self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo ip link set dev %s mtu 1500 2>/dev/null || true; '
+            'sudo ip link set dev %s mtu 1500 2>/dev/null || true' % (
+                iface, peer))
         self._set_kernel_link_state(hypervisor_ip, peer, 'up')
         self._set_kernel_link_state(hypervisor_ip, iface, 'up')
         self._set_ovs_admin_db_only(hypervisor_ip, iface, 'up')
+        self._clear_ovs_ingress_policing(hypervisor_ip, iface)
         self._ssh_run_on_hypervisor(
             hypervisor_ip,
             'sudo ovs-vsctl set Interface %s link_state=up' % iface)
 
-    def _install_tc_ingress_drop(self, hypervisor_ip, iface):
-        """Drop all ingress on the OVS netdev (increments kernel rx_dropped)."""
+    def _set_ovs_ingress_policing(self, hypervisor_ip, iface, rate, burst):
         self._ssh_run_on_hypervisor(
             hypervisor_ip,
-            'sudo tc qdisc add dev %s handle ffff: ingress 2>/dev/null || true; '
-            'sudo tc filter add dev %s parent ffff: protocol all u32 '
-            'match u32 0 0 action drop 2>/dev/null || true' % (iface, iface))
-        self.addCleanup(self._remove_tc_ingress, hypervisor_ip, iface)
+            'sudo ovs-vsctl set Interface %s ingress_policing_rate=%d '
+            'ingress_policing_burst=%d' % (iface, rate, burst))
 
-    def _remove_tc_ingress(self, hypervisor_ip, iface):
+    def _clear_ovs_ingress_policing(self, hypervisor_ip, interface):
+        self._ssh_run_on_hypervisor(
+            hypervisor_ip,
+            'sudo ovs-vsctl set Interface %s ingress_policing_rate=0 '
+            'ingress_policing_burst=0' % interface)
+
+    def _try_install_tc_ingress_drop(self, hypervisor_ip, iface):
+        """Install an ingress drop filter; return False when tc is unavailable."""
         self._ssh_run_unchecked_on_hypervisor(
             hypervisor_ip,
-            'sudo tc qdisc del dev %s ingress 2>/dev/null || true' % iface)
+            'sudo modprobe sch_ingress cls_u32 act_gact 2>/dev/null || true')
+        out = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo tc qdisc add dev %s handle ffff: ingress 2>&1; '
+            'echo __ingress__:$?' % iface)
+        if '__ingress__:0' not in out and 'exists' not in out.lower():
+            out = self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip,
+                'sudo tc qdisc add dev %s clsact 2>&1; echo __clsact__:$?' % (
+                    iface))
+            if '__clsact__:0' not in out and 'exists' not in out.lower():
+                LOG.warning(
+                    'tc ingress/clsact unavailable on %s for %s: %s',
+                    hypervisor_ip, iface, out.strip())
+                return False
+        out = self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo tc filter add dev %s parent ffff: protocol all u32 '
+            'match u32 0 0 action drop 2>&1; echo __filter__:$?' % iface)
+        if '__filter__:0' not in out:
+            out = self._ssh_run_unchecked_on_hypervisor(
+                hypervisor_ip,
+                'sudo tc filter add dev %s ingress protocol all u32 '
+                'match u32 0 0 action drop 2>&1; echo __filter__:$?' % iface)
+            if '__filter__:0' not in out:
+                LOG.warning(
+                    'tc ingress drop filter unavailable on %s for %s: %s',
+                    hypervisor_ip, iface, out.strip())
+                return False
+        self.addCleanup(self._remove_tc_ingress, hypervisor_ip, iface)
+        return True
 
     def _try_install_tc_netem(self, hypervisor_ip, iface, netem_opts):
         """Install a netem root qdisc; return False if sch_netem is unavailable."""
@@ -546,32 +600,55 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             hypervisor_ip,
             'sudo tc qdisc del dev %s root 2>/dev/null || true' % iface)
 
+    def _remove_tc_ingress(self, hypervisor_ip, iface):
+        self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo tc qdisc del dev %s ingress 2>/dev/null || true; '
+            'sudo tc qdisc del dev %s clsact 2>/dev/null || true' % (
+                iface, iface))
+
     def _induce_rx_dropped_on_iface(self, hypervisor_ip, iface, peer,
                                     peer_ip, iface_ip, flood_count, baseline,
-                                    label):
+                                    label, vm_ctx=None):
         """Flood the OVS leg from the host peer; return exporter-mapped delta."""
         self._hypervisor_ping_flood(
             hypervisor_ip, peer, iface_ip, flood_count)
         self._hypervisor_udp_flood(
             hypervisor_ip, peer, peer_ip, iface_ip, flood_count)
+        if vm_ctx:
+            self._flood_udp_dataplane(
+                vm_ctx['ssh_sender'], vm_ctx['bind_ip'], iface_ip,
+                flood_count)
         after = self._ovs_interface_stats(hypervisor_ip, iface)
         return self._log_error_induce_stats(label, baseline, after, 'rx_dropped')
 
     def _induce_veth_rx_dropped(self, hypervisor_ip, iface, peer, peer_ip,
-                                iface_ip, flood_count):
+                                iface_ip, flood_count, vm_ctx=None):
         """Drop inbound traffic on the OVS port while the host peer stays up."""
         self._ensure_veth_port_up(hypervisor_ip, iface)
         baseline = self._ovs_interface_stats(hypervisor_ip, iface)
 
-        self._install_tc_ingress_drop(hypervisor_ip, iface)
+        self._set_ovs_ingress_policing(hypervisor_ip, iface, 100, 10)
+        self.addCleanup(self._clear_ovs_ingress_policing, hypervisor_ip, iface)
         time.sleep(1)
         LOG.warning(
-            'Veth rx_dropped induce: tc ingress drop on %s, flood from %s',
+            'Veth rx_dropped induce: OVS ingress policing on %s, flood from %s',
             iface, peer)
         delta = self._induce_rx_dropped_on_iface(
             hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
-            baseline, 'Veth RX tc ingress drop')
-        self._remove_tc_ingress(hypervisor_ip, iface)
+            baseline, 'Veth RX OVS policing', vm_ctx=vm_ctx)
+        self._clear_ovs_ingress_policing(hypervisor_ip, iface)
+
+        if delta <= 0 and self._try_install_tc_ingress_drop(
+                hypervisor_ip, iface):
+            time.sleep(1)
+            LOG.warning(
+                'Veth rx_dropped induce: tc ingress drop on %s, flood from %s',
+                iface, peer)
+            delta = self._induce_rx_dropped_on_iface(
+                hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
+                baseline, 'Veth RX tc ingress drop', vm_ctx=vm_ctx)
+            self._remove_tc_ingress(hypervisor_ip, iface)
 
         if delta <= 0:
             LOG.warning(
@@ -580,7 +657,7 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             time.sleep(1)
             delta = self._induce_rx_dropped_on_iface(
                 hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
-                baseline, 'Veth RX OVS admin down')
+                baseline, 'Veth RX OVS admin down', vm_ctx=vm_ctx)
             self._set_ovs_admin_db_only(hypervisor_ip, iface, 'up')
 
         if delta <= 0:
@@ -590,17 +667,20 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             time.sleep(1)
             delta = self._induce_rx_dropped_on_iface(
                 hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
-                baseline, 'Veth RX kernel down')
+                baseline, 'Veth RX kernel down', vm_ctx=vm_ctx)
             self._set_kernel_link_state(hypervisor_ip, iface, 'up')
 
         self._ensure_veth_port_up(hypervisor_ip, iface)
         if delta <= 0:
             LOG.warning(
-                'rx_dropped induce finished with delta=0 on %s (baseline=%s)',
-                iface, baseline)
+                'rx_dropped induce finished with delta=0 on %s '
+                '(baseline=%s kernel_rx_dropped=%s)',
+                iface, baseline,
+                self._kernel_iface_stat(hypervisor_ip, iface, 'rx_dropped'))
 
     def _induce_tx_errors_on_iface(self, hypervisor_ip, iface, peer_ip,
-                                   iface_ip, flood_count, baseline, label):
+                                   iface_ip, flood_count, baseline, label,
+                                   vm_ctx=None):
         """Transmit from the OVS leg toward the host peer address."""
         self._hypervisor_ping_flood(
             hypervisor_ip, iface, peer_ip, flood_count)
@@ -609,21 +689,64 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         after = self._ovs_interface_stats(hypervisor_ip, iface)
         return self._log_error_induce_stats(label, baseline, after, 'tx_errors')
 
+    def _induce_tx_errors_via_vm_broadcast(self, hypervisor_ip, iface, vm_ctx,
+                                           flood_count, baseline):
+        """Bridge flood from a VM while the test port is admin-down."""
+        bind_ip = vm_ctx['bind_ip']
+        self._set_ovs_admin_db_only(hypervisor_ip, iface, 'down')
+        time.sleep(1)
+        LOG.warning(
+            'Veth tx_errors induce: OVS admin down on %s, VM broadcast from %s',
+            iface, bind_ip)
+        self._flood_udp_dataplane(
+            vm_ctx['ssh_sender'], bind_ip, '255.255.255.255', flood_count,
+            broadcast=True)
+        after = self._ovs_interface_stats(hypervisor_ip, iface)
+        delta = self._log_error_induce_stats(
+            'Veth TX VM broadcast admin down', baseline, after, 'tx_errors')
+        self._set_ovs_admin_db_only(hypervisor_ip, iface, 'up')
+        return delta
+
     def _induce_veth_tx_errors(self, hypervisor_ip, iface, peer, iface_ip,
-                               peer_ip, flood_count):
+                               peer_ip, flood_count, vm_ctx=None):
         """Force TX failures on the OVS leg (peer address is on the host peer)."""
         self._ensure_veth_port_up(hypervisor_ip, iface)
         baseline = self._ovs_interface_stats(hypervisor_ip, iface)
 
-        self._set_ovs_admin_db_only(hypervisor_ip, iface, 'down')
-        time.sleep(1)
-        LOG.warning(
-            'Veth tx_errors induce: OVS admin down on %s, transmit to %s',
-            iface, peer_ip)
-        delta = self._induce_tx_errors_on_iface(
-            hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline,
-            'Veth TX OVS admin down')
-        self._set_ovs_admin_db_only(hypervisor_ip, iface, 'up')
+        delta = 0
+        if vm_ctx:
+            delta = self._induce_tx_errors_via_vm_broadcast(
+                hypervisor_ip, iface, vm_ctx, flood_count, baseline)
+
+        if delta <= 0:
+            self._set_ovs_admin_db_only(hypervisor_ip, iface, 'down')
+            time.sleep(1)
+            LOG.warning(
+                'Veth tx_errors induce: OVS admin down on %s, transmit to %s',
+                iface, peer_ip)
+            delta = self._induce_tx_errors_on_iface(
+                hypervisor_ip, iface, peer_ip, iface_ip, flood_count, baseline,
+                'Veth TX OVS admin down')
+            self._set_ovs_admin_db_only(hypervisor_ip, iface, 'up')
+
+        if delta <= 0 and vm_ctx:
+            LOG.warning(
+                'Retrying tx_errors via VM broadcast with OVS link down on %s',
+                iface)
+            self._ensure_veth_port_up(hypervisor_ip, iface)
+            self._ssh_run_on_hypervisor(
+                hypervisor_ip,
+                'sudo ovs-vsctl set Interface %s link_state=down' % iface)
+            time.sleep(1)
+            self._flood_udp_dataplane(
+                vm_ctx['ssh_sender'], vm_ctx['bind_ip'], '255.255.255.255',
+                flood_count, broadcast=True)
+            after = self._ovs_interface_stats(hypervisor_ip, iface)
+            delta = self._log_error_induce_stats(
+                'Veth TX VM broadcast link down', baseline, after, 'tx_errors')
+            self._ssh_run_on_hypervisor(
+                hypervisor_ip,
+                'sudo ovs-vsctl set Interface %s link_state=up' % iface)
 
         if delta <= 0:
             LOG.warning(
@@ -671,8 +794,15 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         self._ensure_veth_port_up(hypervisor_ip, iface)
         if delta <= 0:
             LOG.warning(
-                'tx_errors induce finished with delta=0 on %s (baseline=%s)',
-                iface, baseline)
+                'tx_errors induce finished with delta=0 on %s '
+                '(baseline=%s kernel_tx_errors=%s kernel_tx_dropped=%s '
+                'ovs_tx_failure_drops=%s)',
+                iface, baseline,
+                self._kernel_iface_stat(hypervisor_ip, iface, 'tx_errors'),
+                self._kernel_iface_stat(hypervisor_ip, iface, 'tx_dropped'),
+                self._ovs_interface_stat_int(
+                    self._ovs_interface_stats(hypervisor_ip, iface),
+                    'ovs_tx_failure_drops'))
 
     def _attach_error_test_veth(self, hypervisor_ip, preferred_bridge, iface):
         """Attach disposable veth to the VM bridge or a fallback kernel bridge."""
@@ -689,7 +819,8 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
                     iface, preferred_bridge, hypervisor_ip, exc)
         return self._create_test_interface(hypervisor_ip, iface)
 
-    def _run_veth_error_induces(self, hypervisor_ip, bridge, flood_count):
+    def _run_veth_error_induces(self, hypervisor_ip, bridge, flood_count,
+                                vm_ctx=None):
         """Induce rx_dropped/tx_errors on a disposable kernel veth port."""
         iface = ERROR_VETH_IFACE
         self._assert_valid_ifnames(iface)
@@ -723,13 +854,15 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
         baseline_rx_prom = self._prom_error_value(
             hypervisor_ip, iface, 'rx_dropped')
         self._induce_veth_rx_dropped(
-            hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count)
+            hypervisor_ip, iface, peer, peer_ip, iface_ip, flood_count,
+            vm_ctx=vm_ctx)
 
         baseline_tx = self._ovs_interface_stats(hypervisor_ip, iface)
         baseline_tx_prom = self._prom_error_value(
             hypervisor_ip, iface, 'tx_errors')
         self._induce_veth_tx_errors(
-            hypervisor_ip, iface, peer, iface_ip, peer_ip, flood_count)
+            hypervisor_ip, iface, peer, iface_ip, peer_ip, flood_count,
+            vm_ctx=vm_ctx)
 
         after = self._ovs_interface_stats(hypervisor_ip, iface)
         self._log_error_induce_stats(
@@ -877,7 +1010,7 @@ class TestOvsInterfaceErrorMetrics(metrics_base.NetworkExporterMetricsBase):
             ERROR_VETH_IFACE, bridge, hypervisor_ip)
         (veth_ctx, baseline_rx, baseline_tx,
          baseline_rx_prom, baseline_tx_prom) = self._run_veth_error_induces(
-            hypervisor_ip, bridge, flood_count)
+            hypervisor_ip, bridge, flood_count, vm_ctx=ctx)
 
         deltas = self._wait_for_induced_errors(
             veth_ctx, baseline_rx, baseline_tx,

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_memory_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_memory_metrics.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+OVS_MEMORY_HANDLERS_TOTAL_METRIC = (
+    metrics_base.OVS_MEMORY_HANDLERS_TOTAL_METRIC)
+OVS_MEMORY_PORTS_TOTAL_METRIC = metrics_base.OVS_MEMORY_PORTS_TOTAL_METRIC
+OVS_MEMORY_REVALIDATORS_TOTAL_METRIC = (
+    metrics_base.OVS_MEMORY_REVALIDATORS_TOTAL_METRIC)
+OVS_MEMORY_RULES_TOTAL_METRIC = metrics_base.OVS_MEMORY_RULES_TOTAL_METRIC
+OVS_MEMORY_KEYS_TOTAL_METRIC = metrics_base.OVS_MEMORY_KEYS_TOTAL_METRIC
+
+
+class TestOvsMemoryMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovs_memory_* gauges against ovs-appctl memory/show (Suite 6.1)."""
+
+    def test_ovs_memory_handlers_total_reported(self):
+        """Verify ovs_memory_handlers_total on compute and metric-storage."""
+        self._assert_memory_metric_reported(OVS_MEMORY_HANDLERS_TOTAL_METRIC)
+
+    def test_ovs_memory_ports_total_reported(self):
+        """Verify ovs_memory_ports_total on compute and metric-storage."""
+        self._assert_memory_metric_reported(OVS_MEMORY_PORTS_TOTAL_METRIC)
+
+    def test_ovs_memory_revalidators_total_reported(self):
+        """Verify ovs_memory_revalidators_total on compute and metric-storage."""
+        self._assert_memory_metric_reported(
+            OVS_MEMORY_REVALIDATORS_TOTAL_METRIC)
+
+    def test_ovs_memory_rules_total_reported(self):
+        """Verify ovs_memory_rules_total on compute and metric-storage."""
+        self._assert_memory_metric_reported(OVS_MEMORY_RULES_TOTAL_METRIC)
+
+    def test_ovs_memory_keys_total_reported(self):
+        """Verify ovs_memory_keys_total on compute and metric-storage."""
+        self._assert_memory_metric_reported(OVS_MEMORY_KEYS_TOTAL_METRIC)

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_pmd_cpu_usage_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_pmd_cpu_usage_metrics.py
@@ -138,9 +138,13 @@ class TestOvsPmdCpuUsageMetrics(metrics_base.NetworkExporterMetricsBase):
         return shared[0]['ip_address']
 
     def _wait_for_pmd_cpu_usage_with_traffic(self, hypervisor_ip,
-                                             baseline_max_rxq):
+                                             baseline_max_rxq, perf_baseline):
         min_rxq = CONF.nfv_plugin_options.network_exporter_pmd_min_rxq_usage_pct
+        min_busy = CONF.nfv_plugin_options.network_exporter_pmd_min_iterations
+        min_rx = self._pmd_min_packet_threshold()
         peak_rxq = baseline_max_rxq
+        peak_busy = perf_baseline['busy']
+        peak_rx = perf_baseline['rx']
         last_exc = None
         last = {}
         for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
@@ -150,31 +154,45 @@ class TestOvsPmdCpuUsageMetrics(metrics_base.NetworkExporterMetricsBase):
             current_max_rxq = self._max_rxq_usage_percent(
                 hypervisor_ip, output=combined)
             peak_rxq = max(peak_rxq, current_max_rxq)
+            perf_current = self._pmd_perf_activity_totals(hypervisor_ip)
+            live_current = self._pmd_live_activity_totals(
+                hypervisor_ip, metrics_output=combined)
+            peak_busy = max(
+                peak_busy, perf_current['busy'], live_current['busy'])
+            peak_rx = max(peak_rx, perf_current['rx'], live_current['rx'])
+            busy_delta = peak_busy - perf_baseline['busy']
+            rx_delta = peak_rx - perf_baseline['rx']
             last = {
                 'baseline_max_rxq': baseline_max_rxq,
-                'current_max_rxq': current_max_rxq,
                 'peak_max_rxq': peak_rxq,
                 'min_rxq_required': min_rxq,
+                'busy_delta': busy_delta,
+                'rx_delta': rx_delta,
+                'min_busy_required': min_busy,
+                'min_rx_required': min_rx,
                 'overhead_threads': len(overhead),
                 'rxq_series': len(rxq_usage),
             }
             try:
-                self.assertGreaterEqual(
-                    peak_rxq, min_rxq,
-                    'ovs_pmd_rxq_usage peak below %s after traffic: %s' % (
-                        min_rxq, last))
-                self.assertGreaterEqual(
-                    peak_rxq, baseline_max_rxq,
-                    'ovs_pmd_rxq_usage did not sustain or increase: %s' % last)
+                rxq_ok = (
+                    (min_rxq > 0 and peak_rxq >= min_rxq) or
+                    peak_rxq > baseline_max_rxq)
+                perf_ok = busy_delta >= min_busy or rx_delta >= min_rx
+                self.assertTrue(
+                    rxq_ok or perf_ok,
+                    'No PMD CPU usage activity after traffic (need rxq peak '
+                    '>=%s or busy +%s or rx +%s): %s' % (
+                        min_rxq, min_busy, min_rx, last))
                 for metric_name in metrics_base.OVS_PMD_CPU_USAGE_METRICS:
                     self.assertTrue(
                         self._pmd_rxq_aligned_on_output(
                             hypervisor_ip, metric_name, combined),
                         '%s not aligned with pmd-rxq-show: %s' % (
                             metric_name, last))
+                last['activity'] = 'rxq_usage' if rxq_ok else 'pmd_perf'
                 LOG.warning(
-                    'PMD CPU usage validated (attempt %s): %s',
-                    attempt + 1, last)
+                    'PMD CPU usage validated via %s (attempt %s): %s',
+                    last['activity'], attempt + 1, last)
                 return last
             except Exception as exc:
                 last_exc = exc
@@ -212,11 +230,12 @@ class TestOvsPmdCpuUsageMetrics(metrics_base.NetworkExporterMetricsBase):
         hypervisor_ip = sender['hypervisor_ip']
         peer_ip = self._dataplane_peer_ip(sender, receiver)
         baseline_max_rxq = self._max_rxq_usage_percent(hypervisor_ip)
+        perf_baseline = self._pmd_perf_activity_totals(hypervisor_ip)
         LOG.warning(
             'PMD CPU usage test: %s -> %s on %s, baseline max rxq usage %s%%, '
-            'ping count %s',
+            'perf baseline %s, ping count %s',
             sender.get('name', sender['id']), peer_ip, hypervisor_ip,
-            baseline_max_rxq, self._traffic_ping_count())
+            baseline_max_rxq, perf_baseline, self._traffic_ping_count())
 
         ssh_sender = self.get_remote_client(
             sender['fip'], self.instance_user, key_pair['private_key'])
@@ -225,7 +244,8 @@ class TestOvsPmdCpuUsageMetrics(metrics_base.NetworkExporterMetricsBase):
             self._min_expected_packets())
 
         result = self._wait_for_pmd_cpu_usage_with_traffic(
-            hypervisor_ip, baseline_max_rxq)
+            hypervisor_ip, baseline_max_rxq, perf_baseline)
         LOG.warning(
-            'PMD CPU usage OK: peak rxq usage %s%% (baseline %s%%)',
-            result['peak_max_rxq'], result['baseline_max_rxq'])
+            'PMD CPU usage OK via %s: peak rxq %s%% busy +%s rx +%s',
+            result.get('activity', 'unknown'),
+            result['peak_max_rxq'], result['busy_delta'], result['rx_delta'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_pmd_cpu_usage_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_pmd_cpu_usage_metrics.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class TestOvsPmdCpuUsageMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovs_pmd_cpu_overhead and ovs_pmd_rxq_usage (Test Suite 5.3)."""
+
+    TEST_NAME = 'network_exporter_pmd_cpu_usage'
+
+    def _ensure_test_setup(self):
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_pmd_cpu_usage_test_networks(self, test_networks):
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('port_type') == 'direct':
+                continue
+            filtered.append(network)
+        if not any(not net.get('mgmt') for net in filtered):
+            raise unittest.SkipTest(
+                'No shared normal provider test-network in tempest_config.yml '
+                'for %s. Add a test-network with port_type: normal (e.g. '
+                'tag: external) in addition to mgmt.' % self.TEST_NAME)
+        LOG.warning(
+            'PMD CPU usage metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_pmd_cpu_usage_boot_kwargs(self):
+        ports_filter = 'external,normal'
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _boot_pmd_cpu_usage_vms(self):
+        self._ensure_test_setup()
+        boot_kwargs = self._build_pmd_cpu_usage_boot_kwargs()
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = (
+            self._filter_pmd_cpu_usage_test_networks(full_test_networks))
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _traffic_ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+
+    def _min_expected_packets(self):
+        count = self._traffic_ping_count()
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _populate_provider_networks(self, servers):
+        for server in servers:
+            server['provider_networks'] = server.get('trunk_networks', [])
+            server['provider_networks'] += server.get('transparent_networks', [])
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server['id'])['ports']
+            for port in ports:
+                if not port.get('fixed_ips'):
+                    continue
+                provider_dict = {
+                    'network_id': port['network_id'],
+                    'mac_address': port['mac_address'],
+                    'ip_address': port['fixed_ips'][0]['ip_address'],
+                    'port_id': port['id'],
+                }
+                server['provider_networks'].append(provider_dict)
+
+    def _mgmt_network_id(self):
+        mgmt_name = getattr(self, 'mgmt_network', None)
+        if not mgmt_name:
+            return None
+        return self.test_network_dict.get(mgmt_name, {}).get('net-id')
+
+    def _dataplane_peer_ip(self, sender, receiver):
+        mgmt_net_id = self._mgmt_network_id()
+        shared = []
+        for recv_net in receiver['provider_networks']:
+            for send_net in sender['provider_networks']:
+                if recv_net['network_id'] == send_net['network_id']:
+                    shared.append(recv_net)
+                    break
+        if not shared:
+            self.fail(
+                'No shared provider network between VMs %s and %s' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        for net in shared:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net['ip_address']
+        return shared[0]['ip_address']
+
+    def _wait_for_pmd_cpu_usage_with_traffic(self, hypervisor_ip,
+                                             baseline_max_rxq):
+        min_rxq = CONF.nfv_plugin_options.network_exporter_pmd_min_rxq_usage_pct
+        peak_rxq = baseline_max_rxq
+        last_exc = None
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            combined = self._pmd_rxq_and_live_output(hypervisor_ip)
+            overhead, rxq_usage = self._ovs_pmd_rxq_stats(
+                hypervisor_ip, output=combined)
+            current_max_rxq = self._max_rxq_usage_percent(
+                hypervisor_ip, output=combined)
+            peak_rxq = max(peak_rxq, current_max_rxq)
+            last = {
+                'baseline_max_rxq': baseline_max_rxq,
+                'current_max_rxq': current_max_rxq,
+                'peak_max_rxq': peak_rxq,
+                'min_rxq_required': min_rxq,
+                'overhead_threads': len(overhead),
+                'rxq_series': len(rxq_usage),
+            }
+            try:
+                self.assertGreaterEqual(
+                    peak_rxq, min_rxq,
+                    'ovs_pmd_rxq_usage peak below %s after traffic: %s' % (
+                        min_rxq, last))
+                self.assertGreaterEqual(
+                    peak_rxq, baseline_max_rxq,
+                    'ovs_pmd_rxq_usage did not sustain or increase: %s' % last)
+                for metric_name in metrics_base.OVS_PMD_CPU_USAGE_METRICS:
+                    self.assertTrue(
+                        self._pmd_rxq_aligned_on_output(
+                            hypervisor_ip, metric_name, combined),
+                        '%s not aligned with pmd-rxq-show: %s' % (
+                            metric_name, last))
+                LOG.warning(
+                    'PMD CPU usage validated (attempt %s): %s',
+                    attempt + 1, last)
+                return last
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for PMD CPU usage: %s; %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for ovs_pmd CPU usage metrics after traffic. '
+            'Last %s; last error: %s' % (last, last_exc))
+
+    def test_ovs_pmd_cpu_overhead_reported(self):
+        """Verify ovs_pmd_cpu_overhead on compute and metric-storage."""
+        self._assert_pmd_rxq_metric_reported(
+            metrics_base.OVS_PMD_CPU_OVERHEAD_METRIC)
+
+    def test_ovs_pmd_rxq_usage_reported(self):
+        """Verify ovs_pmd_rxq_usage on compute and metric-storage."""
+        self._assert_pmd_rxq_metric_reported(
+            metrics_base.OVS_PMD_RXQ_USAGE_METRIC)
+
+    def test_ovs_pmd_cpu_usage_with_vm_traffic(self):
+        """Boot two VMs, send ICMP, verify PMD overhead and RxQ usage."""
+        servers, key_pair = self._boot_pmd_cpu_usage_vms()
+        self.assertEqual(2, len(servers), 'Test requires exactly two VMs')
+        if not servers[0].get('provider_networks'):
+            if self.test_all_provider_networks and servers[0].get('fip'):
+                self.verify_provider_networks(servers, key_pair)
+            else:
+                self._populate_provider_networks(servers)
+
+        sender, receiver = servers[0], servers[1]
+        hypervisor_ip = sender['hypervisor_ip']
+        peer_ip = self._dataplane_peer_ip(sender, receiver)
+        baseline_max_rxq = self._max_rxq_usage_percent(hypervisor_ip)
+        LOG.warning(
+            'PMD CPU usage test: %s -> %s on %s, baseline max rxq usage %s%%, '
+            'ping count %s',
+            sender.get('name', sender['id']), peer_ip, hypervisor_ip,
+            baseline_max_rxq, self._traffic_ping_count())
+
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        self._send_ping_packets(
+            ssh_sender, peer_ip, self._traffic_ping_count(),
+            self._min_expected_packets())
+
+        result = self._wait_for_pmd_cpu_usage_with_traffic(
+            hypervisor_ip, baseline_max_rxq)
+        LOG.warning(
+            'PMD CPU usage OK: peak rxq usage %s%% (baseline %s%%)',
+            result['peak_max_rxq'], result['baseline_max_rxq'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_pmd_iteration_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_pmd_iteration_metrics.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class TestOvsPmdIterationMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovs_pmd_* iteration counters with VM traffic (Test Suite 5.1)."""
+
+    TEST_NAME = 'network_exporter_pmd_iterations'
+
+    def _ensure_test_setup(self):
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_pmd_iteration_test_networks(self, test_networks):
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('port_type') == 'direct':
+                continue
+            filtered.append(network)
+        if not any(not net.get('mgmt') for net in filtered):
+            raise unittest.SkipTest(
+                'No shared normal provider test-network in tempest_config.yml '
+                'for %s. Add a test-network with port_type: normal (e.g. '
+                'tag: external) in addition to mgmt.' % self.TEST_NAME)
+        LOG.warning(
+            'PMD iteration metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_pmd_iteration_boot_kwargs(self):
+        ports_filter = 'external,normal'
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _boot_pmd_iteration_vms(self):
+        self._ensure_test_setup()
+        boot_kwargs = self._build_pmd_iteration_boot_kwargs()
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = (
+            self._filter_pmd_iteration_test_networks(full_test_networks))
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _traffic_ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+
+    def _min_expected_packets(self):
+        count = self._traffic_ping_count()
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _populate_provider_networks(self, servers):
+        for server in servers:
+            server['provider_networks'] = server.get('trunk_networks', [])
+            server['provider_networks'] += server.get('transparent_networks', [])
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server['id'])['ports']
+            for port in ports:
+                if not port.get('fixed_ips'):
+                    continue
+                provider_dict = {
+                    'network_id': port['network_id'],
+                    'mac_address': port['mac_address'],
+                    'ip_address': port['fixed_ips'][0]['ip_address'],
+                    'port_id': port['id'],
+                }
+                server['provider_networks'].append(provider_dict)
+
+    def _mgmt_network_id(self):
+        mgmt_name = getattr(self, 'mgmt_network', None)
+        if not mgmt_name:
+            return None
+        return self.test_network_dict.get(mgmt_name, {}).get('net-id')
+
+    def _dataplane_peer_ip(self, sender, receiver):
+        mgmt_net_id = self._mgmt_network_id()
+        shared = []
+        for recv_net in receiver['provider_networks']:
+            for send_net in sender['provider_networks']:
+                if recv_net['network_id'] == send_net['network_id']:
+                    shared.append(recv_net)
+                    break
+        if not shared:
+            self.fail(
+                'No shared provider network between VMs %s and %s' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        for net in shared:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net['ip_address']
+        return shared[0]['ip_address']
+
+    def _baseline_iteration_totals(self, hypervisor_ip):
+        return {
+            metric: self._pmd_live_total(hypervisor_ip, metric)
+            for metric in metrics_base.OVS_PMD_ITERATION_METRICS
+        }
+
+    def _perf_iteration_totals(self, hypervisor_ip):
+        return {
+            metric: self._pmd_perf_total(hypervisor_ip, metric)
+            for metric in metrics_base.OVS_PMD_ITERATION_METRICS
+        }
+
+    def _wait_for_pmd_iteration_increase(self, hypervisor_ip, live_baseline,
+                                       perf_baseline):
+        min_inc = CONF.nfv_plugin_options.network_exporter_pmd_min_iterations
+        peaks = dict(live_baseline)
+        last_exc = None
+        last = {}
+        key_metrics = (
+            metrics_base.OVS_PMD_TOTAL_ITERATIONS_METRIC,
+            metrics_base.OVS_PMD_BUSY_ITERATIONS_METRIC,
+        )
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            current = {
+                metric: self._pmd_live_total(hypervisor_ip, metric)
+                for metric in metrics_base.OVS_PMD_ITERATION_METRICS
+            }
+            for metric, value in current.items():
+                peaks[metric] = max(peaks.get(metric, 0), value)
+            perf_current = self._perf_iteration_totals(hypervisor_ip)
+            live_deltas = {
+                metric: peaks[metric] - live_baseline.get(metric, 0)
+                for metric in metrics_base.OVS_PMD_ITERATION_METRICS
+            }
+            perf_deltas = {
+                metric: perf_current[metric] - perf_baseline.get(metric, 0)
+                for metric in metrics_base.OVS_PMD_ITERATION_METRICS
+            }
+            last = {
+                'live_baseline': live_baseline,
+                'live_current': current,
+                'live_peaks': dict(peaks),
+                'live_deltas': live_deltas,
+                'perf_baseline': perf_baseline,
+                'perf_current': perf_current,
+                'perf_deltas': perf_deltas,
+            }
+            try:
+                for metric in key_metrics:
+                    increased = (
+                        live_deltas[metric] >= min_inc or
+                        perf_deltas[metric] >= min_inc)
+                    self.assertTrue(
+                        increased,
+                        '%s did not increase by %s via live :9105 or '
+                        'pmd-perf-show: %s' % (metric, min_inc, last))
+                for metric in key_metrics:
+                    self._assert_pmd_matches_perf_show(
+                        hypervisor_ip, metric)
+                LOG.warning(
+                    'PMD iteration counters increased (attempt %s): %s',
+                    attempt + 1, last)
+                return last
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for PMD iterations: %s; %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for ovs_pmd_* iteration increase. '
+            'Last %s; last error: %s' % (last, last_exc))
+
+    def test_ovs_pmd_total_iterations_reported(self):
+        """Verify ovs_pmd_total_iterations on compute and metric-storage."""
+        self._assert_pmd_metric_reported(
+            metrics_base.OVS_PMD_TOTAL_ITERATIONS_METRIC)
+
+    def test_ovs_pmd_idle_iterations_reported(self):
+        """Verify ovs_pmd_idle_iterations on compute and metric-storage."""
+        self._assert_pmd_metric_reported(
+            metrics_base.OVS_PMD_IDLE_ITERATIONS_METRIC)
+
+    def test_ovs_pmd_busy_iterations_reported(self):
+        """Verify ovs_pmd_busy_iterations on compute and metric-storage."""
+        self._assert_pmd_metric_reported(
+            metrics_base.OVS_PMD_BUSY_ITERATIONS_METRIC)
+
+    def test_ovs_pmd_iterations_increase_with_vm_traffic(self):
+        """Boot two VMs, send ICMP, verify PMD iteration counters grow."""
+        servers, key_pair = self._boot_pmd_iteration_vms()
+        self.assertEqual(2, len(servers), 'Test requires exactly two VMs')
+        if not servers[0].get('provider_networks'):
+            if self.test_all_provider_networks and servers[0].get('fip'):
+                self.verify_provider_networks(servers, key_pair)
+            else:
+                self._populate_provider_networks(servers)
+
+        sender, receiver = servers[0], servers[1]
+        hypervisor_ip = sender['hypervisor_ip']
+        peer_ip = self._dataplane_peer_ip(sender, receiver)
+        live_baseline = self._baseline_iteration_totals(hypervisor_ip)
+        perf_baseline = self._perf_iteration_totals(hypervisor_ip)
+        LOG.warning(
+            'PMD iteration test: %s -> %s on %s, live baseline %s, '
+            'perf baseline %s, ping count %s',
+            sender.get('name', sender['id']), peer_ip, hypervisor_ip,
+            live_baseline, perf_baseline, self._traffic_ping_count())
+
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        self._send_ping_packets(
+            ssh_sender, peer_ip, self._traffic_ping_count(),
+            self._min_expected_packets())
+
+        result = self._wait_for_pmd_iteration_increase(
+            hypervisor_ip, live_baseline, perf_baseline)
+        LOG.warning(
+            'PMD iterations OK: total +%s busy +%s (live peaks %s)',
+            result['live_deltas'][
+                metrics_base.OVS_PMD_TOTAL_ITERATIONS_METRIC],
+            result['live_deltas'][
+                metrics_base.OVS_PMD_BUSY_ITERATIONS_METRIC],
+            result['live_peaks'])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_pmd_packet_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_ovs_pmd_packet_metrics.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger('{} [-] nfv_plugin_test'.format(__name__))
+
+
+class TestOvsPmdPacketMetrics(metrics_base.NetworkExporterMetricsBase):
+    """Verify ovs_pmd_rx/tx_packets with VM traffic (Test Suite 5.2)."""
+
+    TEST_NAME = 'network_exporter_pmd_packets'
+
+    def _ensure_test_setup(self):
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_pmd_packet_test_networks(self, test_networks):
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('port_type') == 'direct':
+                continue
+            filtered.append(network)
+        if not any(not net.get('mgmt') for net in filtered):
+            raise unittest.SkipTest(
+                'No shared normal provider test-network in tempest_config.yml '
+                'for %s. Add a test-network with port_type: normal (e.g. '
+                'tag: external) in addition to mgmt.' % self.TEST_NAME)
+        LOG.warning(
+            'PMD packet metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_pmd_packet_boot_kwargs(self):
+        ports_filter = 'external,normal'
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _boot_pmd_packet_vms(self):
+        self._ensure_test_setup()
+        boot_kwargs = self._build_pmd_packet_boot_kwargs()
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = (
+            self._filter_pmd_packet_test_networks(full_test_networks))
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _traffic_ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_traffic_ping_count
+
+    def _min_expected_packets(self):
+        configured = CONF.nfv_plugin_options.network_exporter_pmd_min_packets
+        if configured:
+            return configured
+        count = self._traffic_ping_count()
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_traffic_packet_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _populate_provider_networks(self, servers):
+        for server in servers:
+            server['provider_networks'] = server.get('trunk_networks', [])
+            server['provider_networks'] += server.get('transparent_networks', [])
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server['id'])['ports']
+            for port in ports:
+                if not port.get('fixed_ips'):
+                    continue
+                provider_dict = {
+                    'network_id': port['network_id'],
+                    'mac_address': port['mac_address'],
+                    'ip_address': port['fixed_ips'][0]['ip_address'],
+                    'port_id': port['id'],
+                }
+                server['provider_networks'].append(provider_dict)
+
+    def _mgmt_network_id(self):
+        mgmt_name = getattr(self, 'mgmt_network', None)
+        if not mgmt_name:
+            return None
+        return self.test_network_dict.get(mgmt_name, {}).get('net-id')
+
+    def _dataplane_peer_ip(self, sender, receiver):
+        mgmt_net_id = self._mgmt_network_id()
+        shared = []
+        for recv_net in receiver['provider_networks']:
+            for send_net in sender['provider_networks']:
+                if recv_net['network_id'] == send_net['network_id']:
+                    shared.append(recv_net)
+                    break
+        if not shared:
+            self.fail(
+                'No shared provider network between VMs %s and %s' % (
+                    sender.get('name', sender['id']),
+                    receiver.get('name', receiver['id'])))
+        for net in shared:
+            if mgmt_net_id and net['network_id'] == mgmt_net_id:
+                continue
+            return net['ip_address']
+        return shared[0]['ip_address']
+
+    def _baseline_packet_totals(self, hypervisor_ip):
+        return {
+            metric: self._pmd_live_total(hypervisor_ip, metric)
+            for metric in metrics_base.OVS_PMD_PACKET_METRICS
+        }
+
+    def _perf_packet_totals(self, hypervisor_ip):
+        return {
+            metric: self._pmd_perf_total(hypervisor_ip, metric)
+            for metric in metrics_base.OVS_PMD_PACKET_METRICS
+        }
+
+    def _wait_for_pmd_packet_increase(self, hypervisor_ip, live_baseline,
+                                      perf_baseline):
+        min_packets = self._min_expected_packets()
+        peaks = dict(live_baseline)
+        last_exc = None
+        last = {}
+        for attempt in range(metrics_base.METRIC_RETRY_ATTEMPTS):
+            current = {
+                metric: self._pmd_live_total(hypervisor_ip, metric)
+                for metric in metrics_base.OVS_PMD_PACKET_METRICS
+            }
+            for metric, value in current.items():
+                peaks[metric] = max(peaks.get(metric, 0), value)
+            perf_current = self._perf_packet_totals(hypervisor_ip)
+            live_deltas = {
+                metric: peaks[metric] - live_baseline.get(metric, 0)
+                for metric in metrics_base.OVS_PMD_PACKET_METRICS
+            }
+            perf_deltas = {
+                metric: perf_current[metric] - perf_baseline.get(metric, 0)
+                for metric in metrics_base.OVS_PMD_PACKET_METRICS
+            }
+            last = {
+                'live_baseline': live_baseline,
+                'live_current': current,
+                'live_peaks': dict(peaks),
+                'live_deltas': live_deltas,
+                'perf_baseline': perf_baseline,
+                'perf_current': perf_current,
+                'perf_deltas': perf_deltas,
+            }
+            try:
+                for metric in metrics_base.OVS_PMD_PACKET_METRICS:
+                    increased = (
+                        live_deltas[metric] >= min_packets or
+                        perf_deltas[metric] >= min_packets)
+                    self.assertTrue(
+                        increased,
+                        '%s did not increase by %s via live :9105 or '
+                        'pmd-perf-show: %s' % (metric, min_packets, last))
+                for metric in metrics_base.OVS_PMD_PACKET_METRICS:
+                    self._assert_pmd_matches_perf_show(
+                        hypervisor_ip, metric)
+                LOG.warning(
+                    'PMD packet counters increased (attempt %s): %s',
+                    attempt + 1, last)
+                return last
+            except Exception as exc:
+                last_exc = exc
+                LOG.warning(
+                    'Attempt %s/%s waiting for PMD packets: %s; %s',
+                    attempt + 1, metrics_base.METRIC_RETRY_ATTEMPTS,
+                    exc, last)
+            if attempt < metrics_base.METRIC_RETRY_ATTEMPTS - 1:
+                time.sleep(metrics_base.METRIC_RETRY_INTERVAL)
+        self.fail(
+            'Timed out waiting for ovs_pmd_rx/tx_packets increase. '
+            'Last %s; last error: %s' % (last, last_exc))
+
+    def test_ovs_pmd_rx_packets_reported(self):
+        """Verify ovs_pmd_rx_packets on compute and metric-storage."""
+        self._assert_pmd_metric_reported(
+            metrics_base.OVS_PMD_RX_PACKETS_METRIC)
+
+    def test_ovs_pmd_tx_packets_reported(self):
+        """Verify ovs_pmd_tx_packets on compute and metric-storage."""
+        self._assert_pmd_metric_reported(
+            metrics_base.OVS_PMD_TX_PACKETS_METRIC)
+
+    def test_ovs_pmd_packet_counters_with_vm_traffic(self):
+        """Boot two VMs, send ICMP, verify PMD rx/tx packet counters grow."""
+        servers, key_pair = self._boot_pmd_packet_vms()
+        self.assertEqual(2, len(servers), 'Test requires exactly two VMs')
+        if not servers[0].get('provider_networks'):
+            if self.test_all_provider_networks and servers[0].get('fip'):
+                self.verify_provider_networks(servers, key_pair)
+            else:
+                self._populate_provider_networks(servers)
+
+        sender, receiver = servers[0], servers[1]
+        hypervisor_ip = sender['hypervisor_ip']
+        peer_ip = self._dataplane_peer_ip(sender, receiver)
+        live_baseline = self._baseline_packet_totals(hypervisor_ip)
+        perf_baseline = self._perf_packet_totals(hypervisor_ip)
+        LOG.warning(
+            'PMD packet test: %s -> %s on %s, live baseline %s, '
+            'perf baseline %s, min packets %s, ping count %s',
+            sender.get('name', sender['id']), peer_ip, hypervisor_ip,
+            live_baseline, perf_baseline, self._min_expected_packets(),
+            self._traffic_ping_count())
+
+        ssh_sender = self.get_remote_client(
+            sender['fip'], self.instance_user, key_pair['private_key'])
+        self._send_ping_packets(
+            ssh_sender, peer_ip, self._traffic_ping_count(),
+            self._min_expected_packets())
+
+        result = self._wait_for_pmd_packet_increase(
+            hypervisor_ip, live_baseline, perf_baseline)
+        LOG.warning(
+            'PMD packets OK: rx +%s tx +%s',
+            result['live_deltas'][metrics_base.OVS_PMD_RX_PACKETS_METRIC],
+            result['live_deltas'][metrics_base.OVS_PMD_TX_PACKETS_METRIC])

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_sriov_vf_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_sriov_vf_metrics.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import base64
+import time
+import unittest
+
+from tempest import config
+
+from nfv_tempest_plugin.tests.scenario.network_exporter import metrics_base
+from nfv_tempest_plugin.tests.scenario.network_exporter import (
+    net_vf_metrics_mixin)
+from oslo_log import log as logging
+
+CONF = config.CONF
+LOG = logging.getLogger("{} [-] nfv_plugin_test".format(__name__))
+
+
+class TestSriovVfMetrics(net_vf_metrics_mixin.NetVfMetricsMixin,
+                         metrics_base.NetworkExporterMetricsBase):
+    """Validate SR-IOV VF metrics presence, labels, and traffic movement."""
+
+    TEST_NAME = 'network_exporter_sriov_vf_metrics'
+
+    def _sriov_ports_filter(self):
+        """Match TestSriovScenarios: attach external (SSH/FIP) + direct SR-IOV."""
+        physnet = CONF.nfv_plugin_options.network_exporter_sriov_physnet.strip()
+        return "external,direct:%s" % physnet if physnet else "external,direct"
+
+    def _ensure_test_setup(self):
+        """Default test config when tests-setup omits this test name."""
+        if self.TEST_NAME not in self.test_setup_dict:
+            self.test_setup_dict[self.TEST_NAME] = {
+                'flavor-id': self.flavor_ref,
+                'router': True,
+                'aggregate': None,
+            }
+
+    def _filter_sriov_test_networks(self, test_networks):
+        """Create mgmt + external + direct ports (same pattern as SR-IOV use cases).
+
+        Keeps provider/external networks for SSH and floating IP access via
+        ports_filter external,direct[:physnet]. Skips unrelated networks (e.g.
+        DPDK-only) to avoid unnecessary port creation.
+        """
+        physnet = CONF.nfv_plugin_options.network_exporter_sriov_physnet.strip()
+        filtered = []
+        for network in test_networks:
+            if network.get('mgmt'):
+                filtered.append(network)
+                continue
+            if network.get('tag') == 'external':
+                filtered.append(network)
+                continue
+            if network.get('port_type') != 'direct':
+                continue
+            if physnet and network.get('physical_network') != physnet:
+                continue
+            filtered.append(network)
+        if not any(net.get('port_type') == 'direct' for net in filtered):
+            raise unittest.SkipTest(
+                'No direct SR-IOV test-network in tempest_config.yml for '
+                '%s. Add a test-network with port_type: direct and '
+                'physical_network matching Neutron (set '
+                'network_exporter_sriov_physnet to select one physnet).' %
+                self.TEST_NAME)
+        LOG.warning(
+            'SR-IOV VF metrics will create test-networks: %s',
+            [net.get('name') for net in filtered])
+        return filtered
+
+    def _build_sriov_boot_kwargs(self):
+        """Resource kwargs aligned with test_nfv_sriov_usecases boot pattern."""
+        ports_filter = self._sriov_ports_filter()
+        srv_details = {
+            0: {'ports_filter': ports_filter},
+            1: {'ports_filter': ports_filter},
+        }
+        hypervisor = CONF.nfv_plugin_options.target_hypervisor
+        if hypervisor:
+            for index in srv_details:
+                srv_details[index]['availability_zone'] = 'nova:%s' % hypervisor
+        return {
+            'num_servers': 2,
+            'mgmt_subnet_only': True,
+            'srv_details': srv_details,
+        }
+
+    def _collect_vm_ports(self, servers):
+        by_server = {}
+        for server in servers:
+            ports = self.os_admin.ports_client.list_ports(
+                device_id=server["id"])["ports"]
+            by_server[server["id"]] = ports
+        return by_server
+
+    def _sriov_port_by_server(self, servers):
+        ports_by_server = self._collect_vm_ports(servers)
+        server_ports = {}
+        for server in servers:
+            direct_ports = [
+                port for port in ports_by_server[server["id"]]
+                if (port.get("binding:vnic_type") == "direct" and
+                    port.get("fixed_ips"))
+            ]
+            if direct_ports:
+                server_ports[server["id"]] = direct_ports
+        return server_ports
+
+    def _select_peer_ports(self, servers):
+        ports_by_server = self._sriov_port_by_server(servers)
+        if len(ports_by_server) < 2:
+            raise unittest.SkipTest(
+                "SR-IOV VF metrics test needs at least two VMs with direct "
+                "ports attached. Set network_exporter_sriov_physnet or "
+                "adjust test resources.")
+        for sender in servers:
+            sender_ports = ports_by_server.get(sender["id"], [])
+            for receiver in servers:
+                if receiver["id"] == sender["id"]:
+                    continue
+                receiver_ports = ports_by_server.get(receiver["id"], [])
+                for sender_port in sender_ports:
+                    for receiver_port in receiver_ports:
+                        if (sender_port["network_id"] ==
+                                receiver_port["network_id"]):
+                            return (sender, sender_port, receiver,
+                                    receiver_port)
+        raise unittest.SkipTest(
+            "No shared SR-IOV direct network between test VMs. Check that "
+            "test resources provide at least one common direct network.")
+
+    def _ping_count(self):
+        return CONF.nfv_plugin_options.network_exporter_sriov_traffic_ping_count
+
+    def _min_expected_packets_for_count(self, count):
+        tolerance = (
+            CONF.nfv_plugin_options.network_exporter_sriov_counter_tolerance_pct)
+        return int(count * (100 - tolerance) / 100)
+
+    def _min_expected_packets(self):
+        return self._min_expected_packets_for_count(self._ping_count())
+
+    def _min_expected_bytes(self):
+        return (self._min_expected_packets() *
+                CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
+
+    def _min_expected_bytes_for_count(self, packet_count):
+        return (self._min_expected_packets_for_count(packet_count) *
+                CONF.nfv_plugin_options.network_exporter_traffic_min_bytes_per_packet)
+
+    def _boot_sriov_vms(self):
+        """Create networks, ports, flavor (if configured), and boot two VMs."""
+        self._ensure_test_setup()
+        boot_kwargs = self._build_sriov_boot_kwargs()
+        LOG.warning(
+            'Booting SR-IOV VMs for %s with ports_filter=%s',
+            self.TEST_NAME, boot_kwargs['srv_details'][0]['ports_filter'])
+        full_test_networks = self.external_config['test-networks']
+        self.external_config['test-networks'] = self._filter_sriov_test_networks(
+            full_test_networks)
+        try:
+            return self.create_and_verify_resources(
+                test=self.TEST_NAME, **boot_kwargs)
+        finally:
+            self.external_config['test-networks'] = full_test_networks
+
+    def _subnet_broadcast_ip(self, ip_address):
+        """Return IPv4 subnet broadcast address for ip_address, or None."""
+        if ':' in ip_address:
+            return None
+        octets = ip_address.split('.')
+        if len(octets) != 4:
+            return None
+        return '.'.join(octets[:3] + ['255'])
+
+    def _build_traffic_context(self):
+        """Boot SR-IOV peer VMs and return sender/receiver dataplane context."""
+        servers, key_pair = self._boot_sriov_vms()
+        sender, sender_port, receiver, receiver_port = self._select_peer_ports(
+            servers)
+        sender_ctx = {
+            "server": sender,
+            "port": sender_port,
+            "hypervisor_ip": sender["hypervisor_ip"],
+            "vf_labels": self._vf_labels_from_mac(
+                sender["hypervisor_ip"], sender_port["mac_address"]),
+        }
+        receiver_ctx = {
+            "server": receiver,
+            "port": receiver_port,
+            "hypervisor_ip": receiver["hypervisor_ip"],
+            "vf_labels": self._vf_labels_from_mac(
+                receiver["hypervisor_ip"], receiver_port["mac_address"]),
+        }
+        peer_ip = receiver_port["fixed_ips"][0]["ip_address"]
+        ip_for_access = sender.get('fip') or sender.get('fixed_ip')
+        ssh_sender = self.get_remote_client(
+            ip_for_access, self.instance_user, key_pair["private_key"])
+        receiver_access_ip = receiver.get('fip') or receiver.get('fixed_ip')
+        ssh_receiver = self.get_remote_client(
+            receiver_access_ip, self.instance_user, key_pair["private_key"])
+        return {
+            "sender": sender_ctx,
+            "receiver": receiver_ctx,
+            "ssh_sender": ssh_sender,
+            "ssh_receiver": ssh_receiver,
+            "peer_ip": peer_ip,
+            "broadcast_ip": self._subnet_broadcast_ip(peer_ip),
+        }
+
+    def _send_multicast_packets(self, ctx, count, min_packets):
+        """Send IPv4 UDP multicast on the SR-IOV L2 segment (no listener)."""
+        bind_ip = ctx['sender']['port']['fixed_ips'][0]['ip_address']
+        if ':' in bind_ip:
+            raise unittest.SkipTest(
+                'Multicast VF metric test needs an IPv4 SR-IOV sender address')
+        group = '224.0.0.1'
+        flood_count = (
+            CONF.nfv_plugin_options.network_exporter_sriov_multicast_flood_packets)
+        LOG.warning(
+            'Sending multicast UDP: %d datagrams to %s:9997 from %s',
+            flood_count, group, bind_ip)
+        script = (
+            'import socket\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            's.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 32)\n'
+            's.bind((%r, 0))\n'
+            'dest = (%r, 9997)\n'
+            'payload = b"x" * 64\n'
+            'for _ in range(%d):\n'
+            '    s.sendto(payload, dest)\n'
+            % (bind_ip, group, flood_count))
+        self._run_guest_python_script(ctx['ssh_sender'], script, timeout_sec=120)
+
+    def _send_broadcast_packets(self, ctx, count, min_packets):
+        """Send IPv4 UDP broadcast on the SR-IOV L2 segment (no reply needed)."""
+        broadcast_ip = ctx.get('broadcast_ip')
+        if not broadcast_ip:
+            raise unittest.SkipTest(
+                'Broadcast VF metric test needs an IPv4 SR-IOV peer address')
+        flood_count = (
+            CONF.nfv_plugin_options.network_exporter_sriov_broadcast_flood_packets)
+        bind_ip = ctx['sender']['port']['fixed_ips'][0]['ip_address']
+        LOG.warning(
+            'Sending broadcast UDP: %d datagrams to %s:9998 from %s',
+            flood_count, broadcast_ip, bind_ip)
+        self._flood_udp_dataplane(
+            ctx['ssh_sender'], bind_ip, broadcast_ip, flood_count,
+            broadcast=True)
+
+    def _guest_sudo_prefix(self, ssh_client):
+        """Return sudo prefix when passwordless sudo is available on the guest."""
+        if self._guest_has_passwordless_sudo(ssh_client):
+            return 'sudo -n'
+        return ''
+
+    def _set_hypervisor_vf_link_state(self, hypervisor_ip, vf_labels, enabled):
+        """Enable or disable SR-IOV VF link state from the compute hypervisor."""
+        state = 'enable' if enabled else 'disable'
+        cmd = 'sudo ip link set dev %s vf %s state %s' % (
+            vf_labels['device'], vf_labels['vf'], state)
+        self._ssh_run_on_hypervisor(hypervisor_ip, cmd)
+
+    def _restore_hypervisor_vf_link(self, hypervisor_ip, vf_labels):
+        """Best-effort re-enable of VF link state after transmit drop test."""
+        self._ssh_run_unchecked_on_hypervisor(
+            hypervisor_ip,
+            'sudo ip link set dev %s vf %s state enable' % (
+                vf_labels['device'], vf_labels['vf']))
+
+    def _induce_transmit_drops(self, ctx, count, min_packets):
+        """Disable host VF link and flood TX from guest (iface stays up)."""
+        sender = ctx['sender']
+        hypervisor_ip = sender['hypervisor_ip']
+        vf_labels = sender['vf_labels']
+        mac_address = sender['port']['mac_address']
+        bind_ip = sender['port']['fixed_ips'][0]['ip_address']
+        peer_ip = ctx['peer_ip']
+        ssh_sender = ctx['ssh_sender']
+        flood_count = (
+            CONF.nfv_plugin_options.network_exporter_sriov_tx_drop_flood_packets)
+
+        self.addCleanup(
+            self._restore_hypervisor_vf_link, hypervisor_ip, vf_labels)
+        self._maybe_shrink_guest_tx_ring(ssh_sender, mac_address)
+        self._set_hypervisor_vf_link_state(
+            hypervisor_ip, vf_labels, False)
+        time.sleep(2)
+
+        sysfs_before = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, 'tx_dropped')
+        LOG.warning(
+            'Inducing transmit drops on %s VF %s: host link disabled, '
+            'guest iface up, %d UDP datagrams %s -> %s (sysfs tx_dropped=%s)',
+            hypervisor_ip, vf_labels, flood_count, bind_ip, peer_ip,
+            sysfs_before)
+        self._flood_udp_dataplane(
+            ssh_sender, bind_ip, peer_ip, flood_count)
+        self._restore_hypervisor_vf_link(hypervisor_ip, vf_labels)
+        sysfs_after = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, 'tx_dropped')
+        LOG.warning(
+            'Transmit drop induce finished on %s VF %s: sysfs tx_dropped '
+            'before=%s after=%s',
+            hypervisor_ip, vf_labels, sysfs_before, sysfs_after)
+        ctx['sysfs_drop_before'] = sysfs_before
+        ctx['sysfs_drop_after'] = sysfs_after
+
+    def _run_guest_python_script(self, ssh_client, script, timeout_sec=60):
+        """Run a Python script on the guest via base64 pipe (avoids quoting)."""
+        encoded = base64.b64encode(script.encode('utf-8')).decode('ascii')
+        cmd = 'timeout %d sh -c \'echo %s | base64 -d | python3\'' % (
+            timeout_sec, encoded)
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if sudo:
+            cmd = '%s %s' % (sudo, cmd)
+        return ssh_client.exec_command(cmd)
+
+    def _maybe_shrink_guest_rx_ring(self, ssh_client, mac_address):
+        """Temporarily shrink RX ring on guest SR-IOV NIC to ease RX drops."""
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if not sudo:
+            return None
+        iface = self._guest_dataplane_iface(ssh_client, mac_address)
+        ssh_client.exec_command(
+            '%s ethtool -G %s rx 32 2>/dev/null || '
+            '%s ethtool -G %s rx 64 2>/dev/null || true' % (
+                sudo, iface, sudo, iface))
+
+        def restore():
+            ssh_client.exec_command(
+                '%s ethtool -G %s rx 512 2>/dev/null || true' % (
+                    sudo, iface))
+
+        self.addCleanup(restore)
+        return iface
+
+    def _maybe_shrink_guest_tx_ring(self, ssh_client, mac_address):
+        """Temporarily shrink TX ring on guest SR-IOV NIC to ease TX drops."""
+        sudo = self._guest_sudo_prefix(ssh_client)
+        if not sudo:
+            return None
+        iface = self._guest_dataplane_iface(ssh_client, mac_address)
+        ssh_client.exec_command(
+            '%s ethtool -G %s tx 32 2>/dev/null || '
+            '%s ethtool -G %s tx 64 2>/dev/null || true' % (
+                sudo, iface, sudo, iface))
+
+        def restore():
+            ssh_client.exec_command(
+                '%s ethtool -G %s tx 512 2>/dev/null || true' % (
+                    sudo, iface))
+
+        self.addCleanup(restore)
+        return iface
+
+    def _flood_udp_dataplane(self, ssh_client, bind_ip, dest_ip, packet_count,
+                             broadcast=False):
+        """Send a UDP flood bound to the SR-IOV guest IP."""
+        bcast = 'True' if broadcast else 'False'
+        script = (
+            'import socket\n'
+            's = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n'
+            'if %s:\n'
+            '    s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)\n'
+            's.bind((%r, 0))\n'
+            'payload = b"x" * 1400\n'
+            'dest = (%r, 9999)\n'
+            'for _ in range(%d):\n'
+            '    try:\n'
+            '        s.sendto(payload, dest)\n'
+            '    except OSError:\n'
+            '        pass\n'
+            % (bcast, bind_ip, dest_ip, packet_count))
+        self._run_guest_python_script(ssh_client, script, timeout_sec=120)
+
+    def _induce_receive_drops(self, ctx, count, min_packets):
+        """Shrink RX ring and flood peer IP to overflow the receiver VF."""
+        if ':' in ctx['peer_ip']:
+            raise unittest.SkipTest(
+                'RX drop flood test currently supports IPv4 SR-IOV peers only')
+        receiver = ctx['receiver']
+        hypervisor_ip = receiver['hypervisor_ip']
+        vf_labels = receiver['vf_labels']
+        bind_ip = ctx['sender']['port']['fixed_ips'][0]['ip_address']
+        flood_count = (
+            CONF.nfv_plugin_options.network_exporter_sriov_rx_drop_flood_packets)
+        self._maybe_shrink_guest_rx_ring(
+            ctx['ssh_receiver'], receiver['port']['mac_address'])
+
+        sysfs_before = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, 'rx_dropped')
+        LOG.warning(
+            'Inducing receive drops on %s VF %s: %d UDP datagrams %s -> %s '
+            'with no listener (sysfs rx_dropped=%s)',
+            hypervisor_ip, vf_labels, flood_count, bind_ip, ctx['peer_ip'],
+            sysfs_before)
+        self._flood_udp_dataplane(
+            ctx['ssh_sender'], bind_ip, ctx['peer_ip'], flood_count)
+        sysfs_after = self._host_vf_sysfs_stat(
+            hypervisor_ip, vf_labels, 'rx_dropped')
+        LOG.warning(
+            'Receive drop induce finished on %s VF %s: sysfs rx_dropped '
+            'before=%s after=%s',
+            hypervisor_ip, vf_labels, sysfs_before, sysfs_after)
+        ctx['sysfs_drop_before'] = sysfs_before
+        ctx['sysfs_drop_after'] = sysfs_after
+
+    # --- Presence: one Tempest result per net_vf metric family ---
+
+    def test_net_vf_info_reported(self):
+        """Verify net_vf_info on compute :9105 and metric-storage Prometheus."""
+        self._assert_net_vf_metric_reported(metrics_base.NET_VF_INFO_METRIC)
+
+    def test_net_vf_receive_packets_total_reported(self):
+        """Verify net_vf_receive_packets_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_RECEIVE_PACKETS_METRIC)
+
+    def test_net_vf_transmit_packets_total_reported(self):
+        """Verify net_vf_transmit_packets_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_TRANSMIT_PACKETS_METRIC)
+
+    def test_net_vf_receive_bytes_total_reported(self):
+        """Verify net_vf_receive_bytes_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_RECEIVE_BYTES_METRIC)
+
+    def test_net_vf_transmit_bytes_total_reported(self):
+        """Verify net_vf_transmit_bytes_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_TRANSMIT_BYTES_METRIC)
+
+    def test_net_vf_broadcast_packets_total_reported(self):
+        """Verify net_vf_broadcast_packets_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_BROADCAST_PACKETS_METRIC)
+
+    def test_net_vf_multicast_packets_total_reported(self):
+        """Verify net_vf_multicast_packets_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_MULTICAST_PACKETS_METRIC)
+
+    # --- Label integrity (net_vf_info only) ---
+
+    def test_net_vf_info_labels_match_host(self):
+        """Verify net_vf_info labels match host VF mapping for VM direct ports."""
+        self._assert_net_vf_metric_reported(metrics_base.NET_VF_INFO_METRIC)
+        servers, _ = self._boot_sriov_vms()
+        sender, sender_port, receiver, receiver_port = self._select_peer_ports(
+            servers)
+        for server, port in ((sender, sender_port), (receiver, receiver_port)):
+            hypervisor_ip = server["hypervisor_ip"]
+            expected_labels = self._vf_labels_from_mac(
+                hypervisor_ip, port["mac_address"])
+            samples = self._prom_samples(
+                hypervisor_ip, metrics_base.NET_VF_INFO_METRIC,
+                required_labels={
+                    "device": expected_labels["device"],
+                    "vf": expected_labels["vf"],
+                    "pci_address": expected_labels["pci_address"],
+                })
+            self.assertNotEmpty(
+                samples,
+                "No net_vf_info sample found on %s for labels %s "
+                "(MAC=%s, server=%s)" % (
+                    hypervisor_ip, expected_labels,
+                    port["mac_address"], server["id"]))
+            exported_numa_nodes = {
+                sample["labels"].get("numa_node", "") for sample in samples}
+            self.assertIn(
+                expected_labels["numa_node"], exported_numa_nodes,
+                "numa_node mismatch for host VF labels %s on %s. "
+                "Exporter returned numa_node values %s" % (
+                    expected_labels, hypervisor_ip,
+                    sorted(exported_numa_nodes)))
+            self._assert_net_vf_metrics_match_metric_storage(
+                hypervisor_ip, metrics_base.NET_VF_INFO_METRIC, {
+                    'device': expected_labels['device'],
+                    'vf': expected_labels['vf'],
+                    'pci_address': expected_labels['pci_address'],
+                })
+
+    def test_net_vf_guest_dataplane_mac_matches_port(self):
+        """Verify each VM SR-IOV dataplane NIC MAC matches its Neutron port."""
+        servers, key_pair = self._boot_sriov_vms()
+        sender, sender_port, receiver, receiver_port = self._select_peer_ports(
+            servers)
+        for server, port in ((sender, sender_port), (receiver, receiver_port)):
+            access_ip = server.get('fip') or server.get('fixed_ip')
+            ssh_client = self.get_remote_client(
+                access_ip, self.instance_user, key_pair['private_key'])
+            self._assert_guest_port_mac(ssh_client, port, server)
+
+    def test_net_vf_guest_dataplane_mac_not_zero(self):
+        """Verify each VM SR-IOV dataplane NIC MAC is not all zeros."""
+        servers, key_pair = self._boot_sriov_vms()
+        sender, sender_port, receiver, receiver_port = self._select_peer_ports(
+            servers)
+        for server, port in ((sender, sender_port), (receiver, receiver_port)):
+            access_ip = server.get('fip') or server.get('fixed_ip')
+            ssh_client = self.get_remote_client(
+                access_ip, self.instance_user, key_pair['private_key'])
+            self._assert_guest_port_mac_not_zero(ssh_client, port, server)
+
+    # --- Traffic: one Tempest result per counter metric ---
+
+    def test_net_vf_transmit_packets_total_increases_with_traffic(self):
+        """Verify net_vf_transmit_packets_total increases on sender VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_TRANSMIT_PACKETS_METRIC, 'sender', 'packets')
+
+    def test_net_vf_receive_packets_total_increases_with_traffic(self):
+        """Verify net_vf_receive_packets_total increases on receiver VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_RECEIVE_PACKETS_METRIC, 'receiver', 'packets')
+
+    def test_net_vf_transmit_bytes_total_increases_with_traffic(self):
+        """Verify net_vf_transmit_bytes_total increases on sender VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_TRANSMIT_BYTES_METRIC, 'sender', 'bytes')
+
+    def test_net_vf_receive_bytes_total_increases_with_traffic(self):
+        """Verify net_vf_receive_bytes_total increases on receiver VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_RECEIVE_BYTES_METRIC, 'receiver', 'bytes')
+
+    def test_net_vf_multicast_packets_total_increases_with_traffic(self):
+        """Verify net_vf_multicast_packets_total increases on receiver VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_MULTICAST_PACKETS_METRIC, 'receiver',
+            'packets', traffic_generator=self._send_multicast_packets,
+            traffic_packet_count=CONF.nfv_plugin_options.
+            network_exporter_sriov_multicast_flood_packets)
+
+    def test_net_vf_broadcast_packets_total_increases_with_traffic(self):
+        """Verify net_vf_broadcast_packets_total increases on receiver VF."""
+        self._test_vf_counter_increases_with_traffic(
+            metrics_base.NET_VF_BROADCAST_PACKETS_METRIC, 'receiver',
+            'packets', traffic_generator=self._send_broadcast_packets,
+            traffic_packet_count=CONF.nfv_plugin_options.
+            network_exporter_sriov_broadcast_flood_packets)
+
+    # --- Drop counters (test_z_* runs last; do not use a TestCase subclass
+    #     for ordering — unittest re-discovers inherited test_* methods) ---
+
+    def test_z_net_vf_receive_dropped_total_reported(self):
+        """Verify net_vf_receive_dropped_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_RECEIVE_DROPPED_METRIC)
+
+    def test_z_net_vf_transmit_dropped_total_reported(self):
+        """Verify net_vf_transmit_dropped_total on compute and metric-storage."""
+        self._assert_net_vf_metric_reported(
+            metrics_base.NET_VF_TRANSMIT_DROPPED_METRIC)
+
+    def test_z_net_vf_transmit_dropped_total_increases_with_traffic(self):
+        """Verify net_vf_transmit_dropped_total increases after TX link-down."""
+        self._test_vf_drop_counter_increases(
+            metrics_base.NET_VF_TRANSMIT_DROPPED_METRIC, 'sender',
+            traffic_generator=self._induce_transmit_drops,
+            sysfs_stat_name='tx_dropped')
+
+    def test_z_net_vf_receive_dropped_total_increases_with_traffic(self):
+        """Verify net_vf_receive_dropped_total increases after RX UDP flood."""
+        self._test_vf_drop_counter_increases(
+            metrics_base.NET_VF_RECEIVE_DROPPED_METRIC, 'receiver',
+            traffic_generator=self._induce_receive_drops,
+            sysfs_stat_name='rx_dropped')

--- a/tools/network_exporter_memory.include
+++ b/tools/network_exporter_memory.include
@@ -1,0 +1,1 @@
+^nfv_tempest_plugin\.tests\.scenario\.network_exporter\.test_ovs_memory_metrics\.

--- a/tools/network_exporter_ovnc.include
+++ b/tools/network_exporter_ovnc.include
@@ -1,0 +1,2 @@
+^nfv_tempest_plugin\.tests\.scenario\.network_exporter\.test_ovnc_config_metrics\.
+^nfv_tempest_plugin\.tests\.scenario\.network_exporter\.test_ovnc_txn_metrics\.

--- a/tools/network_exporter_pmd.include
+++ b/tools/network_exporter_pmd.include
@@ -1,0 +1,3 @@
+^nfv_tempest_plugin\.tests\.scenario\.network_exporter\.test_ovs_pmd_iteration_metrics\.
+^nfv_tempest_plugin\.tests\.scenario\.network_exporter\.test_ovs_pmd_packet_metrics\.
+^nfv_tempest_plugin\.tests\.scenario\.network_exporter\.test_ovs_pmd_cpu_usage_metrics\.


### PR DESCRIPTION
Fixes false matched multiple VF series failures in metric-storage counter checks on multi-compute labs.

Hypervisor filtering for Prometheus samples used ident.split('.')[0] for every identifier. For ctlplane IPs that short form is 192, which matches every compute instance label in a 192.x lab. SR-IOV VF labels (device / vf / pci_address) are identical across identical hardware, so _storage_counter_value treated series from multiple hosts as duplicates for one VF and failed several tests.
