### PR TITLE
fix: test_rx_tx reads wrong nova config file

### DIFF
--- a/nfv_tempest_plugin/tests/scenario/test_nfv_dpdk_usecases.py
+++ b/nfv_tempest_plugin/tests/scenario/test_nfv_dpdk_usecases.py
@@ -191,7 +191,7 @@ class TestDpdkScenarios(base_test.BaseTest, QoSManagerMixin):
 
         check_section = 'libvirt'
         check_value = 'rx_queue_size,tx_queue_size'
-        config_path = CONF.nfv_plugin_options.conf_files['nova']
+        config_path = CONF.nfv_plugin_options.conf_files['cpu_pinning_nova']
 
         for srv in servers:
             LOG.info('Test RX/TX for the {} instance'.format(srv['fip']))


### PR DESCRIPTION
The rx_queue_size and tx_queue_size settings are in 25-cpu-pinning-nova.conf, not 01-nova.conf. The test was comparing the virsh dumpxml values (1024) against 01-nova.conf (512) and failing because they didn't match.