### PR TITLE
fix: never skip SR-IOV VF drop increase tests

### DIFF
--- a/nfv_tempest_plugin/tests/scenario/network_exporter/net_vf_metrics_mixin.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/net_vf_metrics_mixin.py
@@ -732,68 +732,81 @@ class NetVfMetricsMixin(object):
     def _test_vf_drop_counter_increases(
             self, metric_name, endpoint_role, traffic_generator,
             sysfs_stat_name):
-        """Validate net_vf_*_dropped_total increases after induced drops."""
-        self._assert_net_vf_metric_reported(metric_name)
-        ctx = self._build_traffic_context()
-        endpoint = ctx[endpoint_role]
-        hypervisor_ip = endpoint['hypervisor_ip']
-        vf_labels = endpoint['vf_labels']
-        baseline_sysfs = self._host_vf_sysfs_stat(
-            hypervisor_ip, vf_labels, sysfs_stat_name)
-        baseline_prom, baseline_storage = (
-            self._wait_for_vf_prom_storage_aligned(
-                hypervisor_ip, vf_labels, metric_name))
-        self.assertIsNotNone(
-            baseline_prom,
-            '%s missing baseline on %s for labels %s' % (
-                metric_name, hypervisor_ip, vf_labels))
+        """Validate net_vf_*_dropped_total increases after induced drops.
 
-        packet_count = self._ping_count()
-        min_packets = self._min_expected_packets()
-        traffic_generator(ctx, packet_count, min_packets)
+        These tests must return pass or fail (never skip): host VF stats are
+        advisory; Prometheus :9105 and metric-storage are authoritative.
+        """
+        try:
+            self._assert_net_vf_metric_reported(metric_name)
+            ctx = self._build_traffic_context()
+            endpoint = ctx[endpoint_role]
+            hypervisor_ip = endpoint['hypervisor_ip']
+            vf_labels = endpoint['vf_labels']
+            baseline_sysfs = self._host_vf_sysfs_stat(
+                hypervisor_ip, vf_labels, sysfs_stat_name)
+            baseline_prom, baseline_storage = (
+                self._wait_for_vf_prom_storage_aligned(
+                    hypervisor_ip, vf_labels, metric_name))
+            self.assertIsNotNone(
+                baseline_prom,
+                '%s missing baseline on %s for labels %s' % (
+                    metric_name, hypervisor_ip, vf_labels))
 
-        sysfs_before = ctx.get('sysfs_drop_before')
-        sysfs_after = ctx.get('sysfs_drop_after')
-        promql = self._vf_promql_filter(hypervisor_ip, vf_labels, metric_name)
+            packet_count = self._ping_count()
+            min_packets = self._min_expected_packets()
+            traffic_generator(ctx, packet_count, min_packets)
 
-        if (sysfs_before is not None and sysfs_after is not None and
-                sysfs_after > sysfs_before):
-            sysfs_delta = sysfs_after - sysfs_before
-            baseline_sysfs_val = (
-                baseline_sysfs if baseline_sysfs is not None else sysfs_before)
-            final_prom, final_sysfs = (
-                self._wait_for_vf_counter_aligned_with_sysfs(
-                    hypervisor_ip, vf_labels, metric_name, sysfs_stat_name,
-                    baseline_prom, baseline_sysfs_val, sysfs_delta,
-                    sysfs_delta))
-            LOG.warning(
-                '%s validated with sysfs on %s for %s: prom/sysfs=%s '
-                '(baseline prom=%s sysfs=%s, induced %s->%s). %s',
-                metric_name, endpoint_role, hypervisor_ip, final_prom,
-                baseline_prom, baseline_sysfs_val, sysfs_before, final_sysfs,
-                promql)
-            return
+            sysfs_before = ctx.get('sysfs_drop_before')
+            sysfs_after = ctx.get('sysfs_drop_after')
+            promql = self._vf_promql_filter(
+                hypervisor_ip, vf_labels, metric_name)
 
-        if (sysfs_before is not None and sysfs_after is not None and
-                sysfs_after <= sysfs_before):
-            LOG.warning(
-                'Host VF %s on %s unchanged after drop induce '
-                '(before=%s after=%s); requiring Prometheus :9105 and '
-                'metric-storage increase instead. %s',
-                sysfs_stat_name, hypervisor_ip, sysfs_before, sysfs_after,
-                promql)
-        else:
-            LOG.warning(
-                'Host VF %s unavailable around drop induce on %s for '
-                'labels %s (baseline=%s before=%r after=%r, available=%s); '
-                'validating %s via Prometheus delta and metric-storage. %s',
-                sysfs_stat_name, hypervisor_ip, vf_labels, baseline_sysfs,
-                sysfs_before, sysfs_after,
-                self._host_vf_sysfs_stats_available(hypervisor_ip, vf_labels) or
-                'none', metric_name, promql)
-        self._wait_for_vf_prom_and_storage_increase(
-            hypervisor_ip, vf_labels, metric_name, baseline_prom,
-            'drops', min_delta=1, baseline_storage=baseline_storage)
+            if (sysfs_before is not None and sysfs_after is not None and
+                    sysfs_after > sysfs_before):
+                sysfs_delta = sysfs_after - sysfs_before
+                baseline_sysfs_val = (
+                    baseline_sysfs if baseline_sysfs is not None
+                    else sysfs_before)
+                final_prom, final_sysfs = (
+                    self._wait_for_vf_counter_aligned_with_sysfs(
+                        hypervisor_ip, vf_labels, metric_name,
+                        sysfs_stat_name, baseline_prom, baseline_sysfs_val,
+                        sysfs_delta, sysfs_delta))
+                LOG.warning(
+                    '%s validated with sysfs on %s for %s: prom/sysfs=%s '
+                    '(baseline prom=%s sysfs=%s, induced %s->%s). %s',
+                    metric_name, endpoint_role, hypervisor_ip, final_prom,
+                    baseline_prom, baseline_sysfs_val, sysfs_before,
+                    final_sysfs, promql)
+                return
+
+            if (sysfs_before is not None and sysfs_after is not None and
+                    sysfs_after <= sysfs_before):
+                LOG.warning(
+                    'Host VF %s on %s unchanged after drop induce '
+                    '(before=%s after=%s); requiring Prometheus :9105 and '
+                    'metric-storage increase instead. %s',
+                    sysfs_stat_name, hypervisor_ip, sysfs_before,
+                    sysfs_after, promql)
+            else:
+                LOG.warning(
+                    'Host VF %s unavailable around drop induce on %s for '
+                    'labels %s (baseline=%s before=%r after=%r, '
+                    'available=%s); validating %s via Prometheus delta and '
+                    'metric-storage. %s',
+                    sysfs_stat_name, hypervisor_ip, vf_labels, baseline_sysfs,
+                    sysfs_before, sysfs_after,
+                    self._host_vf_sysfs_stats_available(
+                        hypervisor_ip, vf_labels) or 'none',
+                    metric_name, promql)
+            self._wait_for_vf_prom_and_storage_increase(
+                hypervisor_ip, vf_labels, metric_name, baseline_prom,
+                'drops', min_delta=1, baseline_storage=baseline_storage)
+        except unittest.SkipTest as exc:
+            self.fail(
+                '%s must not skip; converted skip into failure: %s' % (
+                    metric_name, exc))
 
     def _test_vf_counter_increases_with_traffic(
             self, metric_name, endpoint_role, counter_kind,

--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_sriov_vf_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_sriov_vf_metrics.py
@@ -318,7 +318,7 @@ class TestSriovVfMetrics(net_vf_metrics_mixin.NetVfMetricsMixin,
         """Bring the guest SR-IOV dataplane iface up or down (needs sudo)."""
         sudo = self._guest_sudo_prefix(ssh_client)
         if not sudo:
-            raise unittest.SkipTest(
+            raise RuntimeError(
                 'Passwordless sudo required on the guest to toggle the '
                 'SR-IOV dataplane interface for drop induction')
         iface = self._guest_dataplane_iface(ssh_client, mac_address)
@@ -364,10 +364,10 @@ class TestSriovVfMetrics(net_vf_metrics_mixin.NetVfMetricsMixin,
         time.sleep(2)
         link_state = self._hypervisor_vf_link_state(hypervisor_ip, vf_labels)
         if link_state and link_state != 'disable':
-            raise unittest.SkipTest(
+            LOG.warning(
                 'Host VF link-state is %r after disable on %s labels %s; '
-                'cannot induce transmit drops' % (
-                    link_state, hypervisor_ip, vf_labels))
+                'continuing flood and requiring Prometheus increase',
+                link_state, hypervisor_ip, vf_labels)
 
         sysfs_before = self._host_vf_sysfs_stat(
             hypervisor_ip, vf_labels, 'tx_dropped')
@@ -468,8 +468,9 @@ class TestSriovVfMetrics(net_vf_metrics_mixin.NetVfMetricsMixin,
         that VF.
         """
         if ':' in ctx['peer_ip']:
-            raise unittest.SkipTest(
-                'RX drop flood test currently supports IPv4 SR-IOV peers only')
+            self.fail(
+                'RX drop flood test currently supports IPv4 SR-IOV peers only '
+                '(peer_ip=%s)' % ctx['peer_ip'])
         receiver = ctx['receiver']
         hypervisor_ip = receiver['hypervisor_ip']
         vf_labels = receiver['vf_labels']
@@ -493,11 +494,11 @@ class TestSriovVfMetrics(net_vf_metrics_mixin.NetVfMetricsMixin,
             self.addCleanup(
                 self._restore_guest_dataplane_iface,
                 ctx['ssh_receiver'], mac_address)
-        except unittest.SkipTest:
+        except (RuntimeError, unittest.SkipTest) as exc:
             LOG.warning(
-                'Guest dataplane down unavailable for RX drop induce on %s; '
-                'continuing with host VF link-state=%r only',
-                hypervisor_ip, link_state or 'unknown')
+                'Guest dataplane down unavailable for RX drop induce on %s '
+                '(%s); continuing with host VF link-state=%r only',
+                hypervisor_ip, exc, link_state or 'unknown')
 
         sysfs_before = self._host_vf_sysfs_stat(
             hypervisor_ip, vf_labels, 'rx_dropped')


### PR DESCRIPTION
Convert drop-path SkipTest into hard failures and keep Prometheus :9105/metric-storage as the required outcome when host VF drop stats do not move after induction.