### PR TITLE
test: disable SR-IOV VF drop counter tests

### DIFF
--- a/nfv_tempest_plugin/tests/scenario/network_exporter/test_sriov_vf_metrics.py
+++ b/nfv_tempest_plugin/tests/scenario/network_exporter/test_sriov_vf_metrics.py
@@ -672,6 +672,8 @@ class TestSriovVfMetrics(net_vf_metrics_mixin.NetVfMetricsMixin,
         self._assert_net_vf_metric_reported(
             metrics_base.NET_VF_TRANSMIT_DROPPED_METRIC)
 
+    @unittest.skip("Drop induction methods unreliable on test hardware - "
+                   "kernel/driver drops don't increment VF sysfs counters")
     def test_z_net_vf_transmit_dropped_total_increases_with_traffic(self):
         """Verify net_vf_transmit_dropped_total increases after TX link-down."""
         self._test_vf_drop_counter_increases(
@@ -679,6 +681,8 @@ class TestSriovVfMetrics(net_vf_metrics_mixin.NetVfMetricsMixin,
             traffic_generator=self._induce_transmit_drops,
             sysfs_stat_name='tx_dropped')
 
+    @unittest.skip("Drop induction methods unreliable on test hardware - "
+                   "kernel/driver drops don't increment VF sysfs counters")
     def test_z_net_vf_receive_dropped_total_increases_with_traffic(self):
         """Verify net_vf_receive_dropped_total increases after RX iface-down flood."""
         self._test_vf_drop_counter_increases(


### PR DESCRIPTION
Disable test_z_net_vf_transmit_dropped_total_increases_with_traffic and test_z_net_vf_receive_dropped_total_increases_with_traffic.

These tests attempt to induce packet drops to verify the net_vf_transmit_dropped_total and net_vf_receive_dropped_total metrics increment correctly. However, all reliable drop induction methods (tc netem, iptables, ip route blackhole, interface toggling, MTU mismatch) cause drops at the kernel level BEFORE packets reach the NIC driver, so the VF's sysfs tx_dropped/rx_dropped counters never increment.

Methods that could cause NIC-level drops (ring buffer manipulation via ethtool -G, VF rate limiting via ip link set vf rate) are not supported by the test hardware:
- ethtool -G fails silently; rings stay at 8192 descriptors
- VF rate limiting not implemented by driver

The drop counter metrics themselves are valid and will increment if real traffic patterns cause NIC-level drops. These tests are disabled until we have access to hardware/tooling that supports reliable NIC-level drop induction for testing purposes.