### PR TITLE
Remove openshift dependency from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ jsonschema===4.16.0 # MIT
 cryptography===38.0.2
 tempest>=27.0.0 # Apache-2.0
 neutron_tempest_plugin>=0.9.0 # Apache-2.0
-openshift

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
+    setup_requires=['pbr>=1.9,<6.0', 'setuptools>=17.1'],
     pbr=True
 )


### PR DESCRIPTION
The openshift package is not in OpenStack 2023.1 upper-constraints, which causes pip install to fail with egg_info error when the test-operator installs the plugin with -c constraints.

The k8s.py module that used openshift is no longer imported after the IGMP snooping tests were refactored to use SSH instead of the k8s API.