### PR TITLE
Add sleep after starting multicast listeners

### DIFF
--- a/nfv_tempest_plugin/tests/scenario/test_igmp_snooping_usecases.py
+++ b/nfv_tempest_plugin/tests/scenario/test_igmp_snooping_usecases.py
@@ -369,6 +369,9 @@ class TestIgmpSnoopingScenarios(base_test.BaseTest):
                                   role['mcast_output'])
                     server['ssh_source'].exec_command(cmd)
 
+        # wait for IGMP reports to be processed by OVN
+        time.sleep(10)
+
         # check groups are created
         for hyp in hypervisors.keys():
 


### PR DESCRIPTION
The IGMP reports sent by listeners need time to be processed by OVN before checking group registration and starting traffic senders. Without this delay, senders may start before OVN has registered the multicast groups, causing listeners to miss traffic intermittently.